### PR TITLE
fixed Makefile to change NVME_SOURCES

### DIFF
--- a/Make/gcc/Makefile
+++ b/Make/gcc/Makefile
@@ -62,7 +62,7 @@ endif
 #Files for the final binary
 
 NVMEOUTFILE = openSeaChest_NVMe
-NVMESOURCES = $(UTIL_SRC_DIR)/openSeaChest_NVMe.c ../../src/EULA.c ../../src/seachest_util_options.c
+NVMESOURCES = $(UTIL_SRC_DIR)/openSeaChest_NVMe.c ../../src/EULA.c ../../src/openseachest_util_options.c
 NVMEOBJS = $(NVMESOURCES:.c=.o)
 
 ERASEOUTFILE = openSeaChest_Erase


### PR DESCRIPTION
`NVME_SOURCES` was pointing to a non-existent file in Makefile.  Fixed the Makefile rule to compile the Release-19.06

Signed-off-by: Akhil Mohan <akhil.mohan@mayadata.io>