### PR TITLE
Update Makefile.openSeaChest_firmware

### DIFF
--- a/Make/gcc/Makefile.openSeaChest_firmware
+++ b/Make/gcc/Makefile.openSeaChest_firmware
@@ -13,7 +13,7 @@
 # 
 
 UTIL_SRC_DIR=../../utils/C/openSeaChest
-CC = gcc
+CC ?= gcc
 LIB_FILE_OUTPUT_DIR=lib
 STRIP = strip
 CFLAGS = -Wall -c -std=gnu99


### PR DESCRIPTION
This fixes builds on FreeBSD with no gcc installed. 