### PR TITLE
Cirrus CI config for FreeBSD builds

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,0 +1,11 @@
+task:
+  name: FreeBSD
+  freebsd_instance:
+    matrix:
+      image_family: freebsd-13-0-snap
+      image_family: freebsd-12-0
+  install_script: pkg install -y git gmake
+  submodules_script: git submodule update --init --recursive --progress
+  release_script:
+    - cd Make/gcc
+    - gmake release

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,12 +1,12 @@
 [submodule "opensea-common"]
 	path = opensea-common
-	url = ../opensea-common.git
+	url = https://github.com/Seagate/opensea-common.git
 [submodule "opensea-transport"]
 	path = opensea-transport
-	url = ../opensea-transport.git
+	url = https://github.com/Seagate/opensea-transport.git
 [submodule "opensea-operations"]
 	path = opensea-operations
-	url = ../opensea-operations.git
+	url = https://github.com/Seagate/opensea-operations.git
 [submodule "wingetopt"]
 	path = wingetopt
 	url = https://github.com/Seagate/wingetopt.git


### PR DESCRIPTION
Here is an example build for the change: https://cirrus-ci.com/build/4573585233936384

In order to enable Cirrus for this repository, an admin of this GitHub organization should enable [Cirrus CI App from GitHub Marketplace](https://github.com/marketplace/cirrus-ci).

/cc @xahmad