### PR TITLE
Do not ignore flags for sub-make invocations

### DIFF
--- a/Make/gcc/Makefile
+++ b/Make/gcc/Makefile
@@ -196,9 +196,9 @@ export CXXFLAGS
 export PROJECT_DEFINES
 
 opensea-libs:
-	$(MAKE) -C ../../opensea-common/Make/gcc
-	$(MAKE) -C ../../opensea-transport/Make/gcc
-	$(MAKE) -C ../../opensea-operations/Make/gcc
+	$(MAKE) $(MAKEFLAG) -C ../../opensea-common/Make/gcc
+	$(MAKE) $(MAKEFLAG) -C ../../opensea-transport/Make/gcc
+	$(MAKE) $(MAKEFLAG) -C ../../opensea-operations/Make/gcc
 
 $(SMARTOUTFILE): $(SMARTOBJS) opensea-libs mkoutputdir
 	$(CC) $(SMARTOBJS) $(LFLAGS) -o $(FILE_OUTPUT_DIR)/$(SMARTOUTFILE)


### PR DESCRIPTION
This fixes a bug where make flags are ignored when building the submodules.

This is a particularly nasty bug if you are cross-compiling.