### PR TITLE
Adding a security doc for future vulnerability disclosures.

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,20 @@
+# openSeaChest Security Policy
+
+We take security seriously seriously. If you find any security vulnerabilities in any of the source code, please report it to us as described below.
+
+## Reporting Security Issues
+
+:warning: **Please do not publicly report any security vulnerabilities via GitHub issues.**
+
+If you have questions or general concerns, please email us at [opensea-build@seagate.com](mailto: opensea-build@seagate.com). 
+
+To report an actual vulnerability, please use the form available at "[Seagate Responsible Vulnerability Disclosure Policy](https://www.seagate.com/legal-privacy/responsible-vulnerability-disclosure-policy/)"
+ 
+
+### Reporting Format
+
+To make your reporting meaningful and help us understand the nature and scope of the issue, please include as much information as possible. 
+
+### Preferred Languages
+
+We prefer all communications to be in English.


### PR DESCRIPTION
Signed-off-by: Muhammad Ahmad <muhammad.ahmad@seagate.com>

-----
[View rendered SECURITY.md](https://github.com/Seagate/openSeaChest/blob/security-doc/SECURITY.md)