### PR TITLE
quick: fix ms-build and meson CI

### DIFF
--- a/.github/workflows/meson.yml
+++ b/.github/workflows/meson.yml
@@ -2,7 +2,7 @@ name: CI for meson build
 
 on:
   push:
-    branches: [ develop, master, release/* ]
+    branches: [ develop, master, release/*, feature/* ]
     tags: [ v* ]
   pull_request:
     branches: [ develop ]
@@ -12,6 +12,7 @@ jobs:
     name: ${{ matrix.config.name }}
     runs-on: ${{ matrix.config.os }}
     strategy:
+      fail-fast: false # so that if one config fails, other won't be cancelled automatically
       matrix:
         config:
         - {
@@ -108,11 +109,10 @@ jobs:
       env:
         CC: ${{ matrix.config.cc }}
         CXX: ${{ matrix.config.cxx }}
-      uses: BSFishy/meson-build@v1.0.3
-      with:
-        action: install
-        setup-options: -Dprefix=/ -Dmandir=/man -Dbindir=/ --buildtype=release
-        meson-version: 0.60.1
+      run: |
+        pip install meson==0.61.1 ninja
+        meson setup build -Dprefix=/ -Dmandir=/man -Dbindir=/ --buildtype=release
+        meson install -C build
 
     - name: Packing release
       env:

--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -6,6 +6,7 @@ on:
       - master
       - develop
       - release/*
+      - feature/*
   pull_request:
     branches:
       - develop
@@ -17,11 +18,11 @@ env:
   # Configuration type to build.
   # You can convert this to a build matrix if you need coverage of multiple configuration types.
   # https://docs.github.com/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
-  BUILD_CONFIGURATION: Release 
+  BUILD_CONFIGURATION: Release
 
 jobs:
   build:
-    runs-on: windows-latest
+    runs-on: windows-2019 # Windows latest is now Win11, which codeQL will not run on
     strategy:
       matrix:
         platform: [ x64, x86 ]


### PR DESCRIPTION
This fix broken CI by BSFishy/meson-build and Windows 2022.
Actually GCC and CLANG on Windows would still fail due to https://github.com/Seagate/opensea-transport/blob/c3ee6cb6c56a17a27fe8369ace4b8edf28eedc7c/src/scsi_helper.c#L9363 introducing `NVME_IDENTIFY_DATA_LEN` without control with `DISABLE_NVME_PASSTHROUGH`. 