### PR TITLE
quick: fix Clang on Windows build by revert meson version to 0.60

### DIFF
--- a/.github/workflows/meson.yml
+++ b/.github/workflows/meson.yml
@@ -110,7 +110,7 @@ jobs:
         CC: ${{ matrix.config.cc }}
         CXX: ${{ matrix.config.cxx }}
       run: |
-        pip install meson==0.61.1 ninja
+        pip install meson==0.60.3 ninja
         meson setup build -Dprefix=/ -Dmandir=/man -Dbindir=/ --buildtype=release
         meson install -C build
 


### PR DESCRIPTION
meson >=0.61 would cause Clang on windows to fail on linking opensea static libraries.

Signed-off-by: ThunderEX <thunderex@gmail.com>