### PR TITLE
ci: more platforms for CI, artifacts and binary optimization

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -10,3 +10,30 @@ task:
   release_script:
     - meson --buildtype=release builddir
     - ninja -C builddir
+
+task:
+  name: windowsservercore:visualstudio2019
+  windows_container:
+    image: cirrusci/windowsservercore:visualstudio2019
+  env:
+    CIRRUS_SHELL: powershell
+
+    # Path to the solution file relative to the root of the project.
+    SOLUTION_FILE_PATH: "Make/VS.2019"
+
+    # Configuration type to build.
+    # You can convert this to a build matrix if you need coverage of multiple configuration types.
+    # https://docs.github.com/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
+    BUILD_CONFIGURATION: "Release"
+
+    matrix:
+      - PLATFORM: "x86"
+      - PLATFORM: "x64"
+  submodules_script: git submodule update --init --recursive --progress
+  build_script: |
+    $vsWhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
+    echo "vswhere: $vsWhere"
+    $msBuild = & $vswhere -products * -latest -requires Microsoft.Component.MSBuild -find MSBuild\**\Bin\MSBuild.exe | select-object -first 1
+    echo "msbuild: $msBuild"
+    echo "$msBuild /m /p:Configuration=${env:BUILD_CONFIGURATION} ${env:SOLUTION_FILE_PATH} /p:Platform=${env:PLATFORM}"
+    & $msBuild /m /p:Configuration=${env:BUILD_CONFIGURATION} ${env:SOLUTION_FILE_PATH} /p:Platform=${env:PLATFORM}

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -8,15 +8,73 @@ on:
 
 jobs:
   build:
-
-    runs-on: ubuntu-latest
+    name: ${{ matrix.config.name }}
+    runs-on: ${{ matrix.config.os }}
+    strategy:
+      fail-fast: false # so that if one config fails, other won't be cancelled automatically
+      matrix:
+        config:
+        - {
+            name: "Windows GCC",
+            os: windows-latest,
+            builddir: "Make/gccWin",
+            makefile: "Makefile.gccWin",
+            release_name: "win-x86_64-gcc",
+            release_extension: ".zip",
+            archive_command: "7z a -tzip -mmt"
+          }
+        - {
+            name: "Ubuntu GCC",
+            os: ubuntu-latest,
+            builddir: "Make/gcc",
+            makefile: "Makefile",
+            release_name: "linux-x86_64-gcc",
+            release_extension: ".tar.xz",
+            archive_command: "tar cvfJ"
+          }
+    defaults:
+      run:
+        shell: bash
 
     steps:
     - uses: actions/checkout@v2
       with:
         submodules: recursive
 
-    - name: make
+    - name: Escape backslash in branch name
+      run: echo "BRANCH_NAME=$(echo ${GITHUB_REF#refs/heads/} | tr / -)" >> $GITHUB_ENV
+
+    - name: Setting release name
+      env:
+        DESTDIR: ${{ format('openSeaChest-{0}-{1}', env.BRANCH_NAME, matrix.config.release_name) }}
       run: |
-        cd Make/gcc
-        make release
+        echo "DESTDIR=${DESTDIR}" >> $GITHUB_ENV
+
+    - name: Add Mingw-w64 to path
+      if: startsWith(matrix.config.name, 'Windows GCC')
+      run: |
+        echo "C:\msys64\mingw64\bin" >> $GITHUB_PATH
+
+    - name: make
+      working-directory: ${{ matrix.config.builddir }}
+      run: |
+        make release -f ${{ matrix.config.makefile }}
+
+    - name: Packing release
+      env:
+        ARCHIVE_EXT: ${{ matrix.config.release_extension }}
+      run: |
+        mkdir build
+        cd build
+        ${{ matrix.config.archive_command }} "${DESTDIR}${ARCHIVE_EXT}" ../${{ matrix.config.builddir }}/openseachest_exes
+
+    - name: Uploading artifacts
+      uses: actions/upload-artifact@v2
+      with:
+        path: ${{ format('./build/{0}{1}', env.DESTDIR, matrix.config.release_extension) }}
+
+    # - name: Publish release
+    #   if: ${{ startsWith(github.ref, 'refs/tags/v') && matrix.config.publish_release }}
+    #   uses: softprops/action-gh-release@v1
+    #   with:
+    #     files: ${{ format('./build/{0}{1}', env.DESTDIR, matrix.config.release_extension) }}

--- a/.github/workflows/meson.yml
+++ b/.github/workflows/meson.yml
@@ -42,18 +42,27 @@ jobs:
             os: windows-latest,
             cc: "gcc.exe",
             cxx: "g++.exe",
+            release_name: "win-x86_64-gcc",
+            release_extension: ".zip",
+            archive_command: "7z a -tzip -mmt"
           }
         - {
             name: "Windows Clang",
             os: windows-latest,
             cc: "clang.exe",
             cxx: "clang++.exe",
+            release_name: "win-x86_64-clang",
+            release_extension: ".zip",
+            archive_command: "7z a -tzip -mmt"
           }
         - {
             name: "Ubuntu GCC",
             os: ubuntu-latest,
             cc: "gcc",
-            cxx: "g++"
+            cxx: "g++",
+            release_name: "linux-x86_64-gcc",
+            release_extension: ".tar.xz",
+            archive_command: "tar cvfJ"
           }
         - {
             name: "Ubuntu Clang",
@@ -96,9 +105,13 @@ jobs:
         Invoke-WebRequest -OutFile "LLVM.exe" ((Invoke-WebRequest "https://api.github.com/repos/llvm/llvm-project/releases/$($env:LLVM_RELID)").Content | ConvertFrom-Json | Select-Object -ExpandProperty assets | Where -Property name -Like "*win64.exe" | Select-Object -First 1).browser_download_url
         7z x LLVM.exe -y -o"C:/Program Files/LLVM"
 
+    - name: Escape backslash in branch name
+      shell: bash
+      run: echo "BRANCH_NAME=$(echo ${GITHUB_REF#refs/heads/} | tr / -)" >> $GITHUB_ENV
+
     - name: Setting release name
       env:
-        DESTDIR: ${{ format('openSeaChest-{0}-{1}', github.ref_name, matrix.config.release_name) }} 
+        DESTDIR: ${{ format('openSeaChest-{0}-{1}', env.BRANCH_NAME, matrix.config.release_name) }}
       run: |
         echo "DESTDIR=${DESTDIR}" >> $GITHUB_ENV
       shell: bash
@@ -117,14 +130,18 @@ jobs:
     - name: Packing release
       env:
         ARCHIVE_EXT: ${{ matrix.config.release_extension }}
-      if: ${{ startsWith(github.ref, 'refs/tags/v') && matrix.config.publish_release }} 
       run: |
         cd build
         ${{ matrix.config.archive_command }} "${DESTDIR}${ARCHIVE_EXT}" $DESTDIR
       shell: bash
-  
+
+    - name: Uploading artifacts
+      uses: actions/upload-artifact@v2
+      with:
+        path: ${{ format('./build/{0}{1}', env.DESTDIR, matrix.config.release_extension) }}
+
     - name: Publish release
-      if: ${{ startsWith(github.ref, 'refs/tags/v') && matrix.config.publish_release }} 
+      if: ${{ startsWith(github.ref, 'refs/tags/v') && matrix.config.publish_release }}
       uses: softprops/action-gh-release@v1
       with:
-        files: ${{ format('./build/{0}{1}', env.DESTDIR,  matrix.config.release_extension) }}
+        files: ${{ format('./build/{0}{1}', env.DESTDIR, matrix.config.release_extension) }}

--- a/Make/gcc/Makefile
+++ b/Make/gcc/Makefile
@@ -17,15 +17,15 @@ CC ?= gcc
 LIB_FILE_OUTPUT_DIR=lib
 STRIP ?= strip
 STRIPOPTS ?=
-CFLAGS ?= -Wall -Wextra -c -std=gnu99
+CFLAGS ?= -Wall -Wextra -c -std=gnu99 -ffunction-sections -fdata-sections
 CFLAGS_I686 ?= -Wall -Wextra -c -m32
 LFLAGS ?= \
-	-Wall \
+	-Wall -Wl,--gc-sections \
 	../../opensea-operations/Make/gcc/$(LIB_FILE_OUTPUT_DIR)/libopensea-operations.a \
 	../../opensea-transport/Make/gcc/$(LIB_FILE_OUTPUT_DIR)/libopensea-transport.a \
 	../../opensea-common/Make/gcc/$(LIB_FILE_OUTPUT_DIR)/libopensea-common.a
 TCGLFLAGS ?= \
-	-Wall \
+	-Wall -Wl,--gc-sections \
 	../../SeaCTCGOperations/Make/gcc/$(LIB_FILE_OUTPUT_DIR)/libSeaCTCGOperations.a \
 	../../SeaCTCG/Make/gcc/$(LIB_FILE_OUTPUT_DIR)/libSeaCTCG.a \
 	../../opensea-operations/Make/gcc/$(LIB_FILE_OUTPUT_DIR)/libopensea-operations.a \

--- a/Make/gcc/Makefile.openSeaChest_firmware
+++ b/Make/gcc/Makefile.openSeaChest_firmware
@@ -17,11 +17,11 @@ CC ?= gcc
 LIB_FILE_OUTPUT_DIR=lib
 STRIP ?= strip
 STRIPOPTS ?= 
-CFLAGS = -Wall -Wextra -c -std=gnu99
+CFLAGS = -Wall -Wextra -c -std=gnu99 -ffunction-sections -fdata-sections
 CFLAGS_I686 = -Wall -Wextra -c -m32
 	
 FWDLLFLAGS = \
-	-Wall \
+	-Wall -Wl,--gc-sections \
 	../../opensea-operations/Make/gcc/$(LIB_FILE_OUTPUT_DIR)/libopensea-operations.a \
 	../../opensea-transport/Make/gcc/$(LIB_FILE_OUTPUT_DIR)/libopensea-transport.a \
 	../../opensea-common/Make/gcc/$(LIB_FILE_OUTPUT_DIR)/libopensea-common.a

--- a/Make/gccWin/Makefile.gccWin
+++ b/Make/gccWin/Makefile.gccWin
@@ -315,7 +315,7 @@ ifneq (,$(findstring basics,$(BUILD_ALL)))
     $(BASICSOUTFILE): $(BASICSOBJS) opensea-libs mkoutputdir
 	$(CC) $(BASICSOBJS) $(LDFLAGS) $(LDLIBS) -o $(FILE_OUTPUT_DIR)/$(BASICSOUTFILE)
 	$(STRIP) -s $(FILE_OUTPUT_DIR)/$(BASICSOUTFILE)
-	./rename_seachest.sh $(FILE_OUTPUT_DIR)/$(BASICSOUTFILE)
+	sh rename_seachest.sh $(FILE_OUTPUT_DIR)/$(BASICSOUTFILE)
 endif
 
 #security
@@ -323,7 +323,7 @@ ifneq (,$(findstring security,$(BUILD_ALL)))
     $(SECURITYOUTFILE): $(SECURITYOBJS) opensea-libs mkoutputdir
 	$(CC) $(SECURITYOBJS) $(LDFLAGS) $(LDLIBS) -o $(FILE_OUTPUT_DIR)/$(SECURITYOUTFILE)
 	$(STRIP) -s $(FILE_OUTPUT_DIR)/$(SECURITYOUTFILE)
-	./rename_seachest.sh $(FILE_OUTPUT_DIR)/$(SECURITYOUTFILE)
+	sh rename_seachest.sh $(FILE_OUTPUT_DIR)/$(SECURITYOUTFILE)
 endif
 
 
@@ -332,7 +332,7 @@ ifneq (,$(findstring configure,$(BUILD_ALL)))
     $(CONFIGUREOUTFILE): $(CONFIGUREOBJS) opensea-libs mkoutputdir
 	$(CC) $(CONFIGUREOBJS) $(LDFLAGS) $(LDLIBS) -o $(FILE_OUTPUT_DIR)/$(CONFIGUREOUTFILE)
 	$(STRIP) -s $(FILE_OUTPUT_DIR)/$(CONFIGUREOUTFILE)
-	./rename_seachest.sh $(FILE_OUTPUT_DIR)/$(CONFIGUREOUTFILE)
+	sh rename_seachest.sh $(FILE_OUTPUT_DIR)/$(CONFIGUREOUTFILE)
 endif
 
 #erase
@@ -341,7 +341,7 @@ ifneq (,$(findstring erase,$(BUILD_ALL)))
     ifneq (,$(findstring DISABLE_TCG_SUPPORT,$(PROJECT_DEFINES)))
 		$(CC) $(ERASEOBJS) $(PROJECT_DEFINES) $(LDFLAGS) $(LDLIBS) -o $(FILE_OUTPUT_DIR)/$(ERASEOUTFILE)
 		$(STRIP) -s $(FILE_OUTPUT_DIR)/$(ERASEOUTFILE)
-		./rename_seachest.sh $(FILE_OUTPUT_DIR)/$(ERASEOUTFILE)
+		sh rename_seachest.sh $(FILE_OUTPUT_DIR)/$(ERASEOUTFILE)
     else
 #		$(CC) $(ERASEOBJS) $(TCGLFLAGS) -o $(FILE_OUTPUT_DIR)/$(ERASEOUTFILE)
 #		$(STRIP) -s $(FILE_OUTPUT_DIR)/$(ERASEOUTFILE)
@@ -353,7 +353,7 @@ ifneq (,$(findstring firmware,$(BUILD_ALL)))
     $(FIRMWAREOUTFILE): $(FIRMWAREOBJS) opensea-libs mkoutputdir
 	$(CC) $(FIRMWAREOBJS) $(LDFLAGS) $(LDLIBS) -o $(FILE_OUTPUT_DIR)/$(FIRMWAREOUTFILE)
 	$(STRIP) -s $(FILE_OUTPUT_DIR)/$(FIRMWAREOUTFILE)
-	./rename_seachest.sh $(FILE_OUTPUT_DIR)/$(FIRMWAREOUTFILE)
+	sh rename_seachest.sh $(FILE_OUTPUT_DIR)/$(FIRMWAREOUTFILE)
 endif
 
 #format
@@ -361,7 +361,7 @@ ifneq (,$(findstring format,$(BUILD_ALL)))
     $(FORMATOUTFILE): $(FORMATOBJS) opensea-libs mkoutputdir
 	$(CC) $(FORMATOBJS) $(LDFLAGS) $(LDLIBS) -o $(FILE_OUTPUT_DIR)/$(FORMATOUTFILE)
 	$(STRIP) -s $(FILE_OUTPUT_DIR)/$(FORMATOUTFILE)
-	./rename_seachest.sh $(FILE_OUTPUT_DIR)/$(FORMATOUTFILE)
+	sh rename_seachest.sh $(FILE_OUTPUT_DIR)/$(FORMATOUTFILE)
 endif
 
 #generictests
@@ -369,7 +369,7 @@ ifneq (,$(findstring generictests,$(BUILD_ALL)))
     $(GENERICTESTSOUTFILE) : $(GENERICTESTSOBJS) opensea-libs mkoutputdir
 	$(CC) $(GENERICTESTSOBJS) $(LDFLAGS) $(LDLIBS) -o $(FILE_OUTPUT_DIR)/$(GENERICTESTSOUTFILE)
 	$(STRIP) -s $(FILE_OUTPUT_DIR)/$(GENERICTESTSOUTFILE)
-	./rename_seachest.sh $(FILE_OUTPUT_DIR)/$(GENERICTESTSOUTFILE)
+	sh rename_seachest.sh $(FILE_OUTPUT_DIR)/$(GENERICTESTSOUTFILE)
 endif
 
 #info
@@ -377,7 +377,7 @@ ifneq (,$(findstring info,$(BUILD_ALL)))
     $(INFOOUTFILE): $(INFOOBJS) opensea-libs mkoutputdir
 	$(CC) $(INFOOBJS) $(LDFLAGS) $(LDLIBS) -o $(FILE_OUTPUT_DIR)/$(INFOOUTFILE)
 	$(STRIP) -s $(FILE_OUTPUT_DIR)/$(INFOOUTFILE)
-	./rename_seachest.sh $(FILE_OUTPUT_DIR)/$(INFOOUTFILE)
+	sh rename_seachest.sh $(FILE_OUTPUT_DIR)/$(INFOOUTFILE)
 endif
 
 #logs
@@ -385,7 +385,7 @@ ifneq (,$(findstring logs,$(BUILD_ALL)))
     $(LOGSOUTFILE): $(LOGSOBJS) opensea-libs mkoutputdir
 	$(CC) $(LOGSOBJS) $(LDFLAGS) $(LDLIBS) -o $(FILE_OUTPUT_DIR)/$(LOGSOUTFILE)
 	$(STRIP) -s $(FILE_OUTPUT_DIR)/$(LOGSOUTFILE)
-	./rename_seachest.sh $(FILE_OUTPUT_DIR)/$(LOGSOUTFILE)
+	sh rename_seachest.sh $(FILE_OUTPUT_DIR)/$(LOGSOUTFILE)
 endif
 
 #nvme
@@ -393,7 +393,7 @@ ifneq (,$(findstring nvme,$(BUILD_ALL)))
     $(NVMEOUTFILE): $(NVMEOBJS) opensea-libs mkoutputdir
 	$(CC) $(NVMEOBJS) $(LDFLAGS) $(LDLIBS) -o $(FILE_OUTPUT_DIR)/$(NVMEOUTFILE)
 	$(STRIP) -s $(FILE_OUTPUT_DIR)/$(NVMEOUTFILE)
-	./rename_seachest.sh $(FILE_OUTPUT_DIR)/$(NVMEOUTFILE)
+	sh rename_seachest.sh $(FILE_OUTPUT_DIR)/$(NVMEOUTFILE)
 endif
 
 #powercontrol
@@ -401,7 +401,7 @@ ifneq (,$(findstring powercontrol,$(BUILD_ALL)))
     $(POWERCONTROLOUTFILE) : $(POWERCONTROLOBJS) opensea-libs mkoutputdir
 	$(CC) $(POWERCONTROLOBJS) $(LDFLAGS) $(LDLIBS) -o $(FILE_OUTPUT_DIR)/$(POWERCONTROLOUTFILE)
 	$(STRIP) -s $(FILE_OUTPUT_DIR)/$(POWERCONTROLOUTFILE)
-	./rename_seachest.sh $(FILE_OUTPUT_DIR)/$(POWERCONTROLOUTFILE)
+	sh rename_seachest.sh $(FILE_OUTPUT_DIR)/$(POWERCONTROLOUTFILE)
 endif
 
 #smart
@@ -409,7 +409,7 @@ ifneq (,$(findstring smart,$(BUILD_ALL)))
     $(SMARTOUTFILE): $(SMARTOBJS) opensea-libs mkoutputdir
 	$(CC) $(SMARTOBJS) $(LDFLAGS) $(LDLIBS) -o $(FILE_OUTPUT_DIR)/$(SMARTOUTFILE)
 	$(STRIP) -s $(FILE_OUTPUT_DIR)/$(SMARTOUTFILE)
-	./rename_seachest.sh $(FILE_OUTPUT_DIR)/$(SMARTOUTFILE)
+	sh rename_seachest.sh $(FILE_OUTPUT_DIR)/$(SMARTOUTFILE)
 endif
 
 #zbd
@@ -417,7 +417,7 @@ ifneq (,$(findstring zbd,$(BUILD_ALL)))
     $(ZBDOUTFILE): $(ZBDOBJS) opensea-libs mkoutputdir
 	$(CC) $(ZBDOBJS) $(LDFLAGS) $(LDLIBS) -o $(FILE_OUTPUT_DIR)/$(ZBDOUTFILE)
 	$(STRIP) -s $(FILE_OUTPUT_DIR)/$(ZBDOUTFILE)
-	./rename_seachest.sh $(FILE_OUTPUT_DIR)/$(ZBDOUTFILE)
+	sh rename_seachest.sh $(FILE_OUTPUT_DIR)/$(ZBDOUTFILE)
 endif
 
 #passthrough
@@ -425,7 +425,7 @@ ifneq (,$(findstring passthrough,$(BUILD_ALL)))
     $(PASSTHROUGHTESTOUTFILE): $(PASSTHROUGHTESTOBJS) opensea-libs mkoutputdir
 	$(CC) $(PASSTHROUGHTESTOBJS) $(LDFLAGS) $(LDLIBS) -o $(FILE_OUTPUT_DIR)/$(PASSTHROUGHTESTOUTFILE)
 	$(STRIP) -s $(FILE_OUTPUT_DIR)/$(PASSTHROUGHTESTOUTFILE)
-	./rename_seachest.sh $(FILE_OUTPUT_DIR)/$(PASSTHROUGHTESTOUTFILE)
+	sh rename_seachest.sh $(FILE_OUTPUT_DIR)/$(PASSTHROUGHTESTOUTFILE)
 endif
 
 #reservations 
@@ -433,7 +433,7 @@ ifneq (,$(findstring reservations,$(BUILD_ALL)))
     $(RESERVATIONSOUTFILE): $(RESERVATIONSOBJS) opensea-libs mkoutputdir
 	$(CC) $(RESERVATIONSOBJS) $(LDFLAGS) $(LDLIBS) -o $(FILE_OUTPUT_DIR)/$(RESERVATIONSOUTFILE)
 	$(STRIP) -s $(FILE_OUTPUT_DIR)/$(RESERVATIONSOUTFILE)
-	./rename_seachest.sh $(FILE_OUTPUT_DIR)/$(RESERVATIONSOUTFILE)
+	sh rename_seachest.sh $(FILE_OUTPUT_DIR)/$(RESERVATIONSOUTFILE)
 endif
 
 %.o: %.c

--- a/meson.build
+++ b/meson.build
@@ -2,7 +2,7 @@ project('openSeaChest', 'c', license: 'MPL-2.0', version: '2.0.2')
 
 c = meson.get_compiler('c')
 
-if c.get_id() == 'gcc'
+if c.get_id() == 'gcc' or c.get_id() == 'clang'
   add_global_arguments(
       '-ffunction-sections',
       '-fdata-sections',

--- a/meson.build
+++ b/meson.build
@@ -2,7 +2,7 @@ project('openSeaChest', 'c', license: 'MPL-2.0', version: '2.0.2')
 
 c = meson.get_compiler('c')
 
-if meson.get_compiler('c').get_id() == 'gcc'
+if c.get_id() == 'gcc'
   add_global_arguments(
       '-ffunction-sections',
       '-fdata-sections',

--- a/meson.build
+++ b/meson.build
@@ -2,6 +2,18 @@ project('openSeaChest', 'c', license: 'MPL-2.0', version: '2.0.2')
 
 c = meson.get_compiler('c')
 
+if meson.get_compiler('c').get_id() == 'gcc'
+  add_global_arguments(
+      '-ffunction-sections',
+      '-fdata-sections',
+      language: 'c',
+  )
+  add_global_link_arguments(
+      '-Wl,--gc-sections',
+      language: 'c',
+  )
+endif
+
 if not get_option('tcg').enabled()
   add_project_arguments('-DDISABLE_TCG_SUPPORT', language : 'c')
 endif


### PR DESCRIPTION
Hi,

I did some minor improvement to CI:

1. add win32 for CirrusCI and add gccWin build for GitHub Actions,
2. enable artifacts for GitHub Actions Make & Meson builds,
3. for GCC, discard unused functions during linking, which reduce binary size by ~40%,
