### PR TITLE
Fix compilation on illumos by avoiding c.get_id() in the meson build script

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -2,7 +2,7 @@ project('openSeaChest', 'c', license: 'MPL-2.0', version: '2.0.2')
 
 c = meson.get_compiler('c')
 
-if c.get_id() == 'gcc' or c.get_id() == 'clang'
+if not (target_machine.system() == 'sunos') and (c.get_id() == 'gcc' or c.get_id() == 'clang')
   add_global_arguments(
       '-ffunction-sections',
       '-fdata-sections',


### PR DESCRIPTION
It seems like a recent change introduced a regression specific to building on illumos. I believe this small change will address the problem. This is almost identical to the recommended fix from this in the comments on another PR: https://github.com/Seagate/opensea-transport/pull/9#issuecomment-1082446879