### PR TITLE
Fixing default 'New Issue' behavior

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: true


### PR DESCRIPTION
All,

I set up the Seagate/.github community health default files so that all of the CORTX repos would inherit from them. Unfortunately, I forgot (apologies!) that your repo also inherits from that. Therefore, I had to do this PR to restore your previous behavior.

Thanks,