### PR TITLE
quick: fix windows clang CI

### DIFF
--- a/.github/workflows/meson.yml
+++ b/.github/workflows/meson.yml
@@ -104,7 +104,7 @@ jobs:
         key: 'llvm-llvm-project-relid-${{ env.LLVM_RELID }}'
 
     - name: Downloading latest clang for Windows
-      if: ${{ !steps.cache-primes.outputs.cache-hit && startsWith(matrix.config.name, 'Windows Clang') }}
+      if: ${{ steps.llvm-cache.outputs.cache-hit != 'true' && startsWith(matrix.config.name, 'Windows Clang') }}
       run: |
         $headers = @{ Authorization = 'Bearer ${{ secrets.GITHUB_TOKEN }}' }
         Invoke-WebRequest -Headers $headers -OutFile "LLVM.exe" ((Invoke-WebRequest -Headers $headers "https://api.github.com/repos/llvm/llvm-project/releases/$($env:LLVM_RELID)").Content | ConvertFrom-Json | Select-Object -ExpandProperty assets | Where -Property name -Like "*win64.exe" | Select-Object -First 1).browser_download_url
@@ -120,10 +120,6 @@ jobs:
       run: |
         echo "DESTDIR=${DESTDIR}" >> $GITHUB_ENV
       shell: bash
-
-    - uses: actions/setup-python@v4
-      with:
-        python-version: '3.9'
 
     - name: Configuring and compiling with meson
       env:

--- a/.github/workflows/meson.yml
+++ b/.github/workflows/meson.yml
@@ -91,7 +91,9 @@ jobs:
 
     - name: Get latest LLVM version
       if: startsWith(matrix.config.name, 'Windows Clang')
-      run: echo "LLVM_RELID=$((Invoke-WebRequest 'https://api.github.com/repos/llvm/llvm-project/releases/latest').Content | ConvertFrom-Json | Select-Object -ExpandProperty id)" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+      run: |
+        $headers = @{ Authorization = 'Bearer ${{ secrets.GITHUB_TOKEN }}' }
+        echo "LLVM_RELID=$((Invoke-WebRequest -Headers $headers 'https://api.github.com/repos/llvm/llvm-project/releases/latest').Content | ConvertFrom-Json | Select-Object -ExpandProperty id)" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
     - name: Restore LLVM from cache
       if: startsWith(matrix.config.name, 'Windows Clang')
@@ -104,7 +106,8 @@ jobs:
     - name: Downloading latest clang for Windows
       if: ${{ !steps.cache-primes.outputs.cache-hit && startsWith(matrix.config.name, 'Windows Clang') }}
       run: |
-        Invoke-WebRequest -OutFile "LLVM.exe" ((Invoke-WebRequest "https://api.github.com/repos/llvm/llvm-project/releases/$($env:LLVM_RELID)").Content | ConvertFrom-Json | Select-Object -ExpandProperty assets | Where -Property name -Like "*win64.exe" | Select-Object -First 1).browser_download_url
+        $headers = @{ Authorization = 'Bearer ${{ secrets.GITHUB_TOKEN }}' }
+        Invoke-WebRequest -Headers $headers -OutFile "LLVM.exe" ((Invoke-WebRequest -Headers $headers "https://api.github.com/repos/llvm/llvm-project/releases/$($env:LLVM_RELID)").Content | ConvertFrom-Json | Select-Object -ExpandProperty assets | Where -Property name -Like "*win64.exe" | Select-Object -First 1).browser_download_url
         7z x LLVM.exe -y -o"C:/Program Files/LLVM"
 
     - name: Escape backslash in branch name


### PR DESCRIPTION
The changes here are:

1. For windows clang workflow, it sometimes report "over the account limit" when downloading LLVM, it may be due to [limit of request to GitHub](https://docs.github.com/en/rest/overview/resources-in-the-rest-api?apiVersion=2022-11-28#requests-from-github-actions), so I try to fix by authenticate request [example](https://github.com/bs-community/blessing-skin-server/blob/dev/.github/workflows/Telegram.yml)
2. Besides, I fixed issue that download of LLVM should be skipped if cache hits but it does not work. I also removed step of setup-python since all runners has already installed python and pip.