### PR TITLE
quick: fix argument zoneID is not applied to reportZones

### DIFF
--- a/utils/C/openSeaChest/openSeaChest_ZBD.c
+++ b/utils/C/openSeaChest/openSeaChest_ZBD.c
@@ -1064,7 +1064,7 @@ int32_t main(int argc, char *argv[])
                     perror("cannot allocate memory for zone descriptors");
                     exit(UTIL_EXIT_OPERATION_FAILURE);
                 }
-                int reportRet = get_Zone_Descriptors(&deviceList[deviceIter], REPORT_ZONES_REPORTING_MODE_FLAG, 0, numberOfZones, zoneDescriptors);
+                int reportRet = get_Zone_Descriptors(&deviceList[deviceIter], REPORT_ZONES_REPORTING_MODE_FLAG, ZONE_ID_FLAG, numberOfZones, zoneDescriptors);
                 switch (reportRet)
                 {
                 case SUCCESS:


### PR DESCRIPTION
The argument `zoneID` is not applied to function `get_Zone_Descriptors`, which lead to `reportZones` will always use zone 0.