### PR TITLE
Add forceNVME flag

### DIFF
--- a/docs/man/man8/openSeaChest_Basics.8
+++ b/docs/man/man8/openSeaChest_Basics.8
@@ -121,6 +121,12 @@ Using this option will force the current drive to
 be treated as a SCSI drive. Only SCSI commands will
 be used to talk to the drive.
 .HP
+\fB\-\-forceNVME\fR
+.IP
+Using this option will force the current drive to
+be treated as a NVME drive. Only NVME commands will
+be used to talk to the drive.
+.HP
 \fB\-h\fR, \fB\-\-help\fR
 .IP
 Show utility options and example usage (this output you see now)

--- a/docs/man/man8/openSeaChest_Configure.8
+++ b/docs/man/man8/openSeaChest_Configure.8
@@ -124,6 +124,12 @@ Using this option will force the current drive to
 be treated as a SCSI drive. Only SCSI commands will
 be used to talk to the drive.
 .HP
+\fB\-\-forceNVME\fR
+.IP
+Using this option will force the current drive to
+be treated as a NVME drive. Only NVME commands will
+be used to talk to the drive.
+.HP
 \fB\-h\fR, \fB\-\-help\fR
 .IP
 Show utility options and example usage (this output you see now)

--- a/docs/man/man8/openSeaChest_Erase.8
+++ b/docs/man/man8/openSeaChest_Erase.8
@@ -119,6 +119,12 @@ Using this option will force the current drive to
 be treated as a SCSI drive. Only SCSI commands will
 be used to talk to the drive.
 .HP
+\fB\-\-forceNVME\fR
+.IP
+Using this option will force the current drive to
+be treated as a NVME drive. Only NVME commands will
+be used to talk to the drive.
+.HP
 \fB\-h\fR, \fB\-\-help\fR
 .IP
 Show utility options and example usage (this output you see now)

--- a/docs/man/man8/openSeaChest_Firmware.8
+++ b/docs/man/man8/openSeaChest_Firmware.8
@@ -115,6 +115,12 @@ Using this option will force the current drive to
 be treated as a SCSI drive. Only SCSI commands will
 be used to talk to the drive.
 .HP
+\fB\-\-forceNVME\fR
+.IP
+Using this option will force the current drive to
+be treated as a NVME drive. Only NVME commands will
+be used to talk to the drive.
+.HP
 \fB\-h\fR, \fB\-\-help\fR
 .IP
 Show utility options and example usage (this output you see now)

--- a/docs/man/man8/openSeaChest_Format.8
+++ b/docs/man/man8/openSeaChest_Format.8
@@ -122,6 +122,12 @@ Using this option will force the current drive to
 be treated as a SCSI drive. Only SCSI commands will
 be used to talk to the drive.
 .HP
+\fB\-\-forceNVME\fR
+.IP
+Using this option will force the current drive to
+be treated as a NVME drive. Only NVME commands will
+be used to talk to the drive.
+.HP
 \fB\-h\fR, \fB\-\-help\fR
 .IP
 Show utility options and example usage (this output you see now)

--- a/docs/man/man8/openSeaChest_GenericTests.8
+++ b/docs/man/man8/openSeaChest_GenericTests.8
@@ -104,6 +104,12 @@ Using this option will force the current drive to
 be treated as a SCSI drive. Only SCSI commands will
 be used to talk to the drive.
 .HP
+\fB\-\-forceNVME\fR
+.IP
+Using this option will force the current drive to
+be treated as a NVME drive. Only NVME commands will
+be used to talk to the drive.
+.HP
 \fB\-h\fR, \fB\-\-help\fR
 .IP
 Show utility options and example usage (this output you see now)

--- a/docs/man/man8/openSeaChest_Info.8
+++ b/docs/man/man8/openSeaChest_Info.8
@@ -98,6 +98,12 @@ Using this option will force the current drive to
 be treated as a SCSI drive. Only SCSI commands will
 be used to talk to the drive.
 .HP
+\fB\-\-forceNVME\fR
+.IP
+Using this option will force the current drive to
+be treated as a NVME drive. Only NVME commands will
+be used to talk to the drive.
+.HP
 \fB\-h\fR, \fB\-\-help\fR
 .IP
 Show utility options and example usage (this output you see now)

--- a/docs/man/man8/openSeaChest_Logs.8
+++ b/docs/man/man8/openSeaChest_Logs.8
@@ -102,6 +102,12 @@ Using this option will force the current drive to
 be treated as a SCSI drive. Only SCSI commands will
 be used to talk to the drive.
 .HP
+\fB\-\-forceNVME\fR
+.IP
+Using this option will force the current drive to
+be treated as a NVME drive. Only NVME commands will
+be used to talk to the drive.
+.HP
 \fB\-h\fR, \fB\-\-help\fR
 .IP
 Show utility options and example usage (this output you see now)

--- a/docs/man/man8/openSeaChest_NVMe.8
+++ b/docs/man/man8/openSeaChest_NVMe.8
@@ -80,6 +80,12 @@ Include the output of \fB\-\-version\fR information in the email.
 .IP
 Display the Seagate End User License Agreement (EULA).
 .HP
+\fB\-\-forceNVME\fR
+.IP
+Using this option will force the current drive to
+be treated as a NVME drive. Only NVME commands will
+be used to talk to the drive.
+.HP
 \fB\-\-modelMatch\fR [model Number]
 .IP
 Use this option to run on all drives matching the provided

--- a/docs/man/man8/openSeaChest_PassthroughTest.8
+++ b/docs/man/man8/openSeaChest_PassthroughTest.8
@@ -99,6 +99,12 @@ Using this option will force the current drive to
 be treated as a SCSI drive. Only SCSI commands will
 be used to talk to the drive.
 .HP
+\fB\-\-forceNVME\fR
+.IP
+Using this option will force the current drive to
+be treated as a NVME drive. Only NVME commands will
+be used to talk to the drive.
+.HP
 \fB\-h\fR, \fB\-\-help\fR
 .IP
 Show utility options and example usage (this output you see now)

--- a/docs/man/man8/openSeaChest_PowerControl.8
+++ b/docs/man/man8/openSeaChest_PowerControl.8
@@ -113,6 +113,12 @@ Using this option will force the current drive to
 be treated as a SCSI drive. Only SCSI commands will
 be used to talk to the drive.
 .HP
+\fB\-\-forceNVME\fR
+.IP
+Using this option will force the current drive to
+be treated as a NVME drive. Only NVME commands will
+be used to talk to the drive.
+.HP
 \fB\-h\fR, \fB\-\-help\fR
 .IP
 Show utility options and example usage (this output you see now)

--- a/docs/man/man8/openSeaChest_Reservations.8
+++ b/docs/man/man8/openSeaChest_Reservations.8
@@ -102,6 +102,12 @@ Using this option will force the current drive to
 be treated as a SCSI drive. Only SCSI commands will
 be used to talk to the drive.
 .HP
+\fB\-\-forceNVME\fR
+.IP
+Using this option will force the current drive to
+be treated as a NVME drive. Only NVME commands will
+be used to talk to the drive.
+.HP
 \fB\-h\fR, \fB\-\-help\fR
 .IP
 Show utility options and example usage (this output you see now)

--- a/docs/man/man8/openSeaChest_SMART.8
+++ b/docs/man/man8/openSeaChest_SMART.8
@@ -114,6 +114,12 @@ Using this option will force the current drive to
 be treated as a SCSI drive. Only SCSI commands will
 be used to talk to the drive.
 .HP
+\fB\-\-forceNVME\fR
+.IP
+Using this option will force the current drive to
+be treated as a NVME drive. Only NVME commands will
+be used to talk to the drive.
+.HP
 \fB\-h\fR, \fB\-\-help\fR
 .IP
 Show utility options and example usage (this output you see now)

--- a/docs/man/man8/openSeaChest_Security.8
+++ b/docs/man/man8/openSeaChest_Security.8
@@ -100,6 +100,12 @@ Using this option will force the current drive to
 be treated as a SCSI drive. Only SCSI commands will
 be used to talk to the drive.
 .HP
+\fB\-\-forceNVME\fR
+.IP
+Using this option will force the current drive to
+be treated as a NVME drive. Only NVME commands will
+be used to talk to the drive.
+.HP
 \fB\-h\fR, \fB\-\-help\fR
 .IP
 Show utility options and example usage (this output you see now)

--- a/docs/man/man8/openSeaChest_ZBD.8
+++ b/docs/man/man8/openSeaChest_ZBD.8
@@ -100,6 +100,12 @@ Using this option will force the current drive to
 be treated as a SCSI drive. Only SCSI commands will
 be used to talk to the drive.
 .HP
+\fB\-\-forceNVME\fR
+.IP
+Using this option will force the current drive to
+be treated as a NVME drive. Only NVME commands will
+be used to talk to the drive.
+.HP
 \fB\-h\fR, \fB\-\-help\fR
 .IP
 Show utility options and example usage (this output you see now)

--- a/include/openseachest_util_options.h
+++ b/include/openseachest_util_options.h
@@ -170,12 +170,14 @@ extern "C"
 
     #define FORCE_SCSI_FLAG forceSCSI
     #define FORCE_ATA_FLAG forceATA
+    #define FORCE_NVME_FLAG forceNVME
     #define FORCE_ATA_PIO_FLAG forcePIOATA
     #define FORCE_ATA_DMA_FLAG forceATADMA
     #define FORCE_ATA_UDMA_FLAG forceATAUDMA
     #define FORCE_DRIVE_TYPE_VARS\
     getOptBool FORCE_SCSI_FLAG = goFalse;\
     getOptBool FORCE_ATA_FLAG = goFalse;\
+    getOptBool FORCE_NVME_FLAG = goFalse;\
     getOptBool FORCE_ATA_PIO_FLAG = goFalse;\
     getOptBool FORCE_ATA_DMA_FLAG = goFalse;\
     getOptBool FORCE_ATA_UDMA_FLAG = goFalse;
@@ -183,6 +185,8 @@ extern "C"
     #define FORCE_SCSI_LONG_OPT { FORCE_SCSI_LONG_OPT_STRING, no_argument, &FORCE_SCSI_FLAG, goTrue }
     #define FORCE_ATA_LONG_OPT_STRING "forceATA"
     #define FORCE_ATA_LONG_OPT { FORCE_ATA_LONG_OPT_STRING, no_argument, &FORCE_ATA_FLAG, goTrue }
+    #define FORCE_NVME_LONG_OPT_STRING "forceNVME"
+    #define FORCE_NVME_LONG_OPT { FORCE_NVME_LONG_OPT_STRING, no_argument, &FORCE_NVME_FLAG, goTrue }
     #define FORCE_ATA_PIO_LONG_OPT_STRING "forceATAPIO"
     #define FORCE_ATA_PIO_LONG_OPT { FORCE_ATA_PIO_LONG_OPT_STRING, no_argument, &FORCE_ATA_PIO_FLAG, goTrue }
     #define FORCE_ATA_DMA_LONG_OPT_STRING "forceATADMA"
@@ -190,7 +194,7 @@ extern "C"
     #define FORCE_ATA_UDMA_LONG_OPT_STRING "forceATAUDMA"
     #define FORCE_ATA_UDMA_LONG_OPT { FORCE_ATA_UDMA_LONG_OPT_STRING, no_argument, &FORCE_ATA_UDMA_FLAG, goTrue }
     #define FORCE_DRIVE_TYPE_LONG_OPTS \
-    FORCE_SCSI_LONG_OPT, FORCE_ATA_LONG_OPT, FORCE_ATA_PIO_LONG_OPT, FORCE_ATA_DMA_LONG_OPT, FORCE_ATA_UDMA_LONG_OPT
+    FORCE_SCSI_LONG_OPT, FORCE_ATA_LONG_OPT, FORCE_NVME_LONG_OPT, FORCE_ATA_PIO_LONG_OPT, FORCE_ATA_DMA_LONG_OPT, FORCE_ATA_UDMA_LONG_OPT
 
     #define USE_MAX_LBA useMaxLBA
     #define USE_CHILD_MAX_LBA useChildMaxLBA

--- a/utils/C/openSeaChest/openSeaChest_Basics.c
+++ b/utils/C/openSeaChest/openSeaChest_Basics.c
@@ -39,7 +39,7 @@
 ////////////////////////
 const char *util_name = "openSeaChest_Basics";
 
-const char *buildVersion = "3.5.4";
+const char *buildVersion = "3.6.0";
 
 ////////////////////////////
 //  functions to declare  //
@@ -818,6 +818,8 @@ int main(int argc, char *argv[])
     }
 
     if ((FORCE_SCSI_FLAG && FORCE_ATA_FLAG)
+	|| (FORCE_SCSI_FLAG && FORCE_NVME_FLAG)
+	|| (FORCE_ATA_FLAG && FORCE_NVME_FLAG)
         || (FORCE_ATA_PIO_FLAG && FORCE_ATA_DMA_FLAG && FORCE_ATA_UDMA_FLAG)
         || (FORCE_ATA_PIO_FLAG && FORCE_ATA_DMA_FLAG)
         || (FORCE_ATA_PIO_FLAG && FORCE_ATA_UDMA_FLAG)
@@ -1094,6 +1096,15 @@ int main(int argc, char *argv[])
                 printf("\tForcing ATA Drive\n");
             }
             deviceList[deviceIter].drive_info.drive_type = ATA_DRIVE;
+        }
+
+        if (FORCE_NVME_FLAG)
+        {
+            if (VERBOSITY_QUIET < toolVerbosity)
+            {
+                printf("\tForcing NVME Drive\n");
+            }
+            deviceList[deviceIter].drive_info.drive_type = NVME_DRIVE;
         }
 
         if (FORCE_ATA_PIO_FLAG)

--- a/utils/C/openSeaChest/openSeaChest_Configure.c
+++ b/utils/C/openSeaChest/openSeaChest_Configure.c
@@ -34,7 +34,7 @@
 //  Global Variables  //
 ////////////////////////
 const char *util_name = "openSeaChest_Configure";
-const char *buildVersion = "2.6.0";
+const char *buildVersion = "2.7.0";
 
 ////////////////////////////
 //  functions to declare  //
@@ -1493,6 +1493,8 @@ int32_t main(int argc, char *argv[])
     }
 
     if ((FORCE_SCSI_FLAG && FORCE_ATA_FLAG)
+	|| (FORCE_SCSI_FLAG && FORCE_NVME_FLAG)
+	|| (FORCE_ATA_FLAG && FORCE_NVME_FLAG)
         || (FORCE_ATA_PIO_FLAG && FORCE_ATA_DMA_FLAG && FORCE_ATA_UDMA_FLAG)
         || (FORCE_ATA_PIO_FLAG && FORCE_ATA_DMA_FLAG)
         || (FORCE_ATA_PIO_FLAG && FORCE_ATA_UDMA_FLAG)
@@ -1788,6 +1790,15 @@ int32_t main(int argc, char *argv[])
                 printf("\tForcing ATA Drive\n");
             }
             deviceList[deviceIter].drive_info.drive_type = ATA_DRIVE;
+        }
+
+        if (FORCE_NVME_FLAG)
+        {
+            if (VERBOSITY_QUIET < toolVerbosity)
+            {
+                printf("\tForcing NVME Drive\n");
+            }
+            deviceList[deviceIter].drive_info.drive_type = NVME_DRIVE;
         }
 
         if (FORCE_ATA_PIO_FLAG)

--- a/utils/C/openSeaChest/openSeaChest_Erase.c
+++ b/utils/C/openSeaChest/openSeaChest_Erase.c
@@ -47,7 +47,7 @@
 //  Global Variables  //
 ////////////////////////
 const char *util_name = "openSeaChest_Erase";
-const char *buildVersion = "4.3.6";
+const char *buildVersion = "4.4.0";
 
 typedef enum _eSeaChestEraseExitCodes
 {
@@ -1145,6 +1145,8 @@ int32_t main(int argc, char *argv[])
     }
 
     if ((FORCE_SCSI_FLAG && FORCE_ATA_FLAG)
+	|| (FORCE_SCSI_FLAG && FORCE_NVME_FLAG)
+	|| (FORCE_ATA_FLAG && FORCE_NVME_FLAG)
         || (FORCE_ATA_PIO_FLAG && FORCE_ATA_DMA_FLAG && FORCE_ATA_UDMA_FLAG)
         || (FORCE_ATA_PIO_FLAG && FORCE_ATA_DMA_FLAG)
         || (FORCE_ATA_PIO_FLAG && FORCE_ATA_UDMA_FLAG)
@@ -1464,6 +1466,15 @@ int32_t main(int argc, char *argv[])
                 printf("\tForcing ATA Drive\n");
             }
             deviceList[deviceIter].drive_info.drive_type = ATA_DRIVE;
+        }
+
+        if (FORCE_NVME_FLAG)
+        {
+            if (VERBOSITY_QUIET < toolVerbosity)
+            {
+                printf("\tForcing NVME Drive\n");
+            }
+            deviceList[deviceIter].drive_info.drive_type = NVME_DRIVE;
         }
 
         if (FORCE_ATA_PIO_FLAG)

--- a/utils/C/openSeaChest/openSeaChest_Firmware.c
+++ b/utils/C/openSeaChest/openSeaChest_Firmware.c
@@ -29,7 +29,7 @@
 //  Global Variables  //
 ////////////////////////
 const char *util_name = "openSeaChest_Firmware";
-const char *buildVersion = "4.0.0";
+const char *buildVersion = "4.1.0";
 
 typedef enum _eSeaChestFirmwareExitCodes
 {
@@ -566,6 +566,8 @@ int32_t main(int argc, char *argv[])
     }
 
     if ((FORCE_SCSI_FLAG && FORCE_ATA_FLAG)
+	|| (FORCE_SCSI_FLAG && FORCE_NVME_FLAG)
+	|| (FORCE_ATA_FLAG && FORCE_NVME_FLAG)
         || (FORCE_ATA_PIO_FLAG && FORCE_ATA_DMA_FLAG && FORCE_ATA_UDMA_FLAG)
         || (FORCE_ATA_PIO_FLAG && FORCE_ATA_DMA_FLAG)
         || (FORCE_ATA_PIO_FLAG && FORCE_ATA_UDMA_FLAG)
@@ -848,6 +850,15 @@ int32_t main(int argc, char *argv[])
                 printf("\tForcing ATA Drive\n");
             }
             deviceList[deviceIter].drive_info.drive_type = ATA_DRIVE;
+        }
+
+        if (FORCE_NVME_FLAG)
+        {
+            if (VERBOSITY_QUIET < toolVerbosity)
+            {
+                printf("\tForcing NVME Drive\n");
+            }
+            deviceList[deviceIter].drive_info.drive_type = NVME_DRIVE;
         }
 
         if (FORCE_ATA_PIO_FLAG)

--- a/utils/C/openSeaChest/openSeaChest_Format.c
+++ b/utils/C/openSeaChest/openSeaChest_Format.c
@@ -32,7 +32,7 @@
 //  Global Variables  //
 ////////////////////////
 const char *util_name = "openSeaChest_Format";
-const char *buildVersion = "3.0.4";
+const char *buildVersion = "3.1.0";
 
 ////////////////////////////
 //  functions to declare  //
@@ -765,6 +765,8 @@ int32_t main(int argc, char *argv[])
     }
 
     if ((FORCE_SCSI_FLAG && FORCE_ATA_FLAG)
+	|| (FORCE_SCSI_FLAG && FORCE_NVME_FLAG)
+	|| (FORCE_ATA_FLAG && FORCE_NVME_FLAG)
         || (FORCE_ATA_PIO_FLAG && FORCE_ATA_DMA_FLAG && FORCE_ATA_UDMA_FLAG)
         || (FORCE_ATA_PIO_FLAG && FORCE_ATA_DMA_FLAG)
         || (FORCE_ATA_PIO_FLAG && FORCE_ATA_UDMA_FLAG)
@@ -1080,6 +1082,15 @@ int32_t main(int argc, char *argv[])
                 printf("\tForcing ATA Drive\n");
             }
             deviceList[deviceIter].drive_info.drive_type = ATA_DRIVE;
+        }
+
+        if (FORCE_NVME_FLAG)
+        {
+            if (VERBOSITY_QUIET < toolVerbosity)
+            {
+                printf("\tForcing NVME Drive\n");
+            }
+            deviceList[deviceIter].drive_info.drive_type = NVME_DRIVE;
         }
 
         if (FORCE_ATA_PIO_FLAG)

--- a/utils/C/openSeaChest/openSeaChest_GenericTests.c
+++ b/utils/C/openSeaChest/openSeaChest_GenericTests.c
@@ -30,7 +30,7 @@
 //  Global Variables  //
 ////////////////////////
 const char *util_name = "openSeaChest_GenericTests";
-const char *buildVersion = "2.2.2";
+const char *buildVersion = "2.3.0";
 
 ////////////////////////////
 //  functions to declare  //
@@ -685,6 +685,8 @@ int32_t main(int argc, char *argv[])
     }
 
     if ((FORCE_SCSI_FLAG && FORCE_ATA_FLAG)
+	|| (FORCE_SCSI_FLAG && FORCE_NVME_FLAG)
+	|| (FORCE_ATA_FLAG && FORCE_NVME_FLAG)
         || (FORCE_ATA_PIO_FLAG && FORCE_ATA_DMA_FLAG && FORCE_ATA_UDMA_FLAG)
         || (FORCE_ATA_PIO_FLAG && FORCE_ATA_DMA_FLAG)
         || (FORCE_ATA_PIO_FLAG && FORCE_ATA_UDMA_FLAG)
@@ -947,6 +949,15 @@ int32_t main(int argc, char *argv[])
                 printf("\tForcing ATA Drive\n");
             }
             deviceList[deviceIter].drive_info.drive_type = ATA_DRIVE;
+        }
+
+        if (FORCE_NVME_FLAG)
+        {
+            if (VERBOSITY_QUIET < toolVerbosity)
+            {
+                printf("\tForcing NVME Drive\n");
+            }
+            deviceList[deviceIter].drive_info.drive_type = NVME_DRIVE;
         }
 
         if (FORCE_ATA_PIO_FLAG)

--- a/utils/C/openSeaChest/openSeaChest_Info.c
+++ b/utils/C/openSeaChest/openSeaChest_Info.c
@@ -36,7 +36,7 @@
 //  Global Variables  //
 ////////////////////////
 const char *util_name = "openSeaChest_Info";
-const char *buildVersion = "2.6.0";
+const char *buildVersion = "2.7.0";
 
 ////////////////////////////
 //  functions to declare  //
@@ -533,6 +533,8 @@ int32_t main(int argc, char *argv[])
     }
 
     if ((FORCE_SCSI_FLAG && FORCE_ATA_FLAG)
+	|| (FORCE_SCSI_FLAG && FORCE_NVME_FLAG)
+	|| (FORCE_ATA_FLAG && FORCE_NVME_FLAG)
         || (FORCE_ATA_PIO_FLAG && FORCE_ATA_DMA_FLAG && FORCE_ATA_UDMA_FLAG)
         || (FORCE_ATA_PIO_FLAG && FORCE_ATA_DMA_FLAG)
         || (FORCE_ATA_PIO_FLAG && FORCE_ATA_UDMA_FLAG)
@@ -795,6 +797,15 @@ int32_t main(int argc, char *argv[])
                 printf("\tForcing ATA Drive\n");
             }
             deviceList[deviceIter].drive_info.drive_type = ATA_DRIVE;
+        }
+
+        if (FORCE_NVME_FLAG)
+        {
+            if (VERBOSITY_QUIET < toolVerbosity)
+            {
+                printf("\tForcing NVME Drive\n");
+            }
+            deviceList[deviceIter].drive_info.drive_type = NVME_DRIVE;
         }
 
         if (FORCE_ATA_PIO_FLAG)

--- a/utils/C/openSeaChest/openSeaChest_Logs.c
+++ b/utils/C/openSeaChest/openSeaChest_Logs.c
@@ -34,7 +34,7 @@
 //  Global Variables  //
 ////////////////////////
 const char *util_name = "openSeaChest_Logs";
-const char *buildVersion = "2.4.0";
+const char *buildVersion = "2.5.0";
 
 ////////////////////////////
 //  functions to declare  //
@@ -613,6 +613,8 @@ int32_t main(int argc, char *argv[])
     }
 
     if ((FORCE_SCSI_FLAG && FORCE_ATA_FLAG)
+	|| (FORCE_SCSI_FLAG && FORCE_NVME_FLAG)
+	|| (FORCE_ATA_FLAG && FORCE_NVME_FLAG)
         || (FORCE_ATA_PIO_FLAG && FORCE_ATA_DMA_FLAG && FORCE_ATA_UDMA_FLAG)
         || (FORCE_ATA_PIO_FLAG && FORCE_ATA_DMA_FLAG)
         || (FORCE_ATA_PIO_FLAG && FORCE_ATA_UDMA_FLAG)
@@ -874,6 +876,15 @@ int32_t main(int argc, char *argv[])
                 printf("\tForcing ATA Drive\n");
             }
             deviceList[deviceIter].drive_info.drive_type = ATA_DRIVE;
+        }
+
+        if (FORCE_NVME_FLAG)
+        {
+            if (VERBOSITY_QUIET < toolVerbosity)
+            {
+                printf("\tForcing NVME Drive\n");
+            }
+            deviceList[deviceIter].drive_info.drive_type = NVME_DRIVE;
         }
 
         if (FORCE_ATA_PIO_FLAG)

--- a/utils/C/openSeaChest/openSeaChest_NVMe.c
+++ b/utils/C/openSeaChest/openSeaChest_NVMe.c
@@ -35,7 +35,7 @@
 //  Global Variables  //
 ////////////////////////
 const char *util_name = "openSeaChest_NVMe";
-const char *buildVersion = "2.3.0";
+const char *buildVersion = "2.4.0";
 
 ////////////////////////////
 //  functions to declare  //
@@ -107,6 +107,7 @@ int32_t main(int argc, char *argv[])
     PROGRESS_VAR
     SHOW_SUPPORTED_FORMATS_VAR
     LOWLEVEL_INFO_VAR
+    FORCE_DRIVE_TYPE_VARS
 
     int  args = 0;
     int argIndex = 0;
@@ -160,6 +161,7 @@ int32_t main(int argc, char *argv[])
         SHOW_SUPPORTED_FORMATS_LONG_OPT,
         NVM_FORMAT_LONG_OPT,
         NVM_FORMAT_OPTIONS_LONG_OPTS,
+        FORCE_DRIVE_TYPE_LONG_OPTS,
         LONG_OPT_TERMINATOR
     };
 
@@ -906,6 +908,15 @@ int32_t main(int argc, char *argv[])
     for (uint32_t deviceIter = 0; deviceIter < DEVICE_LIST_COUNT; ++deviceIter)
     {
         deviceList[deviceIter].deviceVerbosity = toolVerbosity;
+        if (FORCE_NVME_FLAG)
+        {
+            if (VERBOSITY_QUIET < toolVerbosity)
+            {
+                printf("\tForcing NVME Drive\n");
+            }
+            deviceList[deviceIter].drive_info.drive_type = NVME_DRIVE;
+        }
+
         if (ONLY_SEAGATE_FLAG)
         {
             if (is_Seagate_Family(&deviceList[deviceIter]) == NON_SEAGATE)

--- a/utils/C/openSeaChest/openSeaChest_PassthroughTest.c
+++ b/utils/C/openSeaChest/openSeaChest_PassthroughTest.c
@@ -33,7 +33,7 @@
 //  Global Variables  //
 ////////////////////////
 const char *util_name = "openSeaChest_PassthroughTest";
-const char *buildVersion = "1.3.3";
+const char *buildVersion = "1.4.0";
 
 ////////////////////////////
 //  functions to declare  //
@@ -707,6 +707,8 @@ int32_t main(int argc, char *argv[])
     }
 
     if ((FORCE_SCSI_FLAG && FORCE_ATA_FLAG)
+	|| (FORCE_SCSI_FLAG && FORCE_NVME_FLAG)
+	|| (FORCE_ATA_FLAG && FORCE_NVME_FLAG)
         || (FORCE_ATA_PIO_FLAG && FORCE_ATA_DMA_FLAG && FORCE_ATA_UDMA_FLAG)
         || (FORCE_ATA_PIO_FLAG && FORCE_ATA_DMA_FLAG)
         || (FORCE_ATA_PIO_FLAG && FORCE_ATA_UDMA_FLAG)
@@ -967,6 +969,15 @@ int32_t main(int argc, char *argv[])
                 printf("\tForcing ATA Drive\n");
             }
             deviceList[deviceIter].drive_info.drive_type = ATA_DRIVE;
+        }
+
+        if (FORCE_NVME_FLAG)
+        {
+            if (VERBOSITY_QUIET < toolVerbosity)
+            {
+                printf("\tForcing NVME Drive\n");
+            }
+            deviceList[deviceIter].drive_info.drive_type = NVME_DRIVE;
         }
 
         if (FORCE_ATA_PIO_FLAG)

--- a/utils/C/openSeaChest/openSeaChest_PowerControl.c
+++ b/utils/C/openSeaChest/openSeaChest_PowerControl.c
@@ -31,7 +31,7 @@
 //  Global Variables  //
 ////////////////////////
 const char *util_name = "openSeaChest_PowerControl";
-const char *buildVersion = "3.5.0";
+const char *buildVersion = "3.6.0";
 
 ////////////////////////////
 //  functions to declare  //
@@ -961,6 +961,8 @@ int32_t main(int argc, char *argv[])
     }
 
     if ((FORCE_SCSI_FLAG && FORCE_ATA_FLAG)
+	|| (FORCE_SCSI_FLAG && FORCE_NVME_FLAG)
+	|| (FORCE_ATA_FLAG && FORCE_NVME_FLAG)
         || (FORCE_ATA_PIO_FLAG && FORCE_ATA_DMA_FLAG && FORCE_ATA_UDMA_FLAG)
         || (FORCE_ATA_PIO_FLAG && FORCE_ATA_DMA_FLAG)
         || (FORCE_ATA_PIO_FLAG && FORCE_ATA_UDMA_FLAG)
@@ -1248,6 +1250,15 @@ int32_t main(int argc, char *argv[])
                 printf("\tForcing ATA Drive\n");
             }
             deviceList[deviceIter].drive_info.drive_type = ATA_DRIVE;
+        }
+
+        if (FORCE_NVME_FLAG)
+        {
+            if (VERBOSITY_QUIET < toolVerbosity)
+            {
+                printf("\tForcing NVME Drive\n");
+            }
+            deviceList[deviceIter].drive_info.drive_type = NVME_DRIVE;
         }
 
         if (FORCE_ATA_PIO_FLAG)

--- a/utils/C/openSeaChest/openSeaChest_Reservations.c
+++ b/utils/C/openSeaChest/openSeaChest_Reservations.c
@@ -29,7 +29,7 @@
 //  Global Variables  //
 ////////////////////////
 const char *util_name = "openSeaChest_Reservations";
-const char *buildVersion = "0.2.1";
+const char *buildVersion = "0.3.0";
 
 ////////////////////////////
 //  functions to declare  //
@@ -529,6 +529,8 @@ int32_t main(int argc, char *argv[])
     }
 
     if ((FORCE_SCSI_FLAG && FORCE_ATA_FLAG)
+	|| (FORCE_SCSI_FLAG && FORCE_NVME_FLAG)
+	|| (FORCE_ATA_FLAG && FORCE_NVME_FLAG)
         || (FORCE_ATA_PIO_FLAG && FORCE_ATA_DMA_FLAG && FORCE_ATA_UDMA_FLAG)
         || (FORCE_ATA_PIO_FLAG && FORCE_ATA_DMA_FLAG)
         || (FORCE_ATA_PIO_FLAG && FORCE_ATA_UDMA_FLAG)
@@ -791,6 +793,15 @@ int32_t main(int argc, char *argv[])
                 printf("\tForcing ATA Drive\n");
             }
             deviceList[deviceIter].drive_info.drive_type = ATA_DRIVE;
+        }
+
+        if (FORCE_NVME_FLAG)
+        {
+            if (VERBOSITY_QUIET < toolVerbosity)
+            {
+                printf("\tForcing NVME Drive\n");
+            }
+            deviceList[deviceIter].drive_info.drive_type = NVME_DRIVE;
         }
 
         if (FORCE_ATA_PIO_FLAG)

--- a/utils/C/openSeaChest/openSeaChest_SMART.c
+++ b/utils/C/openSeaChest/openSeaChest_SMART.c
@@ -33,7 +33,7 @@
 //  Global Variables  //
 ////////////////////////
 const char *util_name = "openSeaChest_SMART";
-const char *buildVersion = "2.4.0";
+const char *buildVersion = "2.5.0";
 
 ////////////////////////////
 //  functions to declare  //
@@ -759,6 +759,8 @@ int32_t main(int argc, char *argv[])
     }
 
     if ((FORCE_SCSI_FLAG && FORCE_ATA_FLAG)
+	|| (FORCE_SCSI_FLAG && FORCE_NVME_FLAG)
+	|| (FORCE_ATA_FLAG && FORCE_NVME_FLAG)
         || (FORCE_ATA_PIO_FLAG && FORCE_ATA_DMA_FLAG && FORCE_ATA_UDMA_FLAG)
         || (FORCE_ATA_PIO_FLAG && FORCE_ATA_DMA_FLAG)
         || (FORCE_ATA_PIO_FLAG && FORCE_ATA_UDMA_FLAG)
@@ -1033,6 +1035,15 @@ int32_t main(int argc, char *argv[])
                 printf("\tForcing ATA Drive\n");
             }
             deviceList[deviceIter].drive_info.drive_type = ATA_DRIVE;
+        }
+
+        if (FORCE_NVME_FLAG)
+        {
+            if (VERBOSITY_QUIET < toolVerbosity)
+            {
+                printf("\tForcing NVME Drive\n");
+            }
+            deviceList[deviceIter].drive_info.drive_type = NVME_DRIVE;
         }
 
         if (FORCE_ATA_PIO_FLAG)

--- a/utils/C/openSeaChest/openSeaChest_Sample.c
+++ b/utils/C/openSeaChest/openSeaChest_Sample.c
@@ -28,7 +28,7 @@
 //  Global Variables  //
 ////////////////////////
 const char *util_name = "openSeaChest_Sample";
-const char *buildVersion = "1.2.1";
+const char *buildVersion = "1.3.0";
 
 ////////////////////////////
 //  functions to declare  //
@@ -436,6 +436,8 @@ int32_t main(int argc, char *argv[])
     }
 
     if ((FORCE_SCSI_FLAG && FORCE_ATA_FLAG)
+	|| (FORCE_SCSI_FLAG && FORCE_NVME_FLAG)
+	|| (FORCE_ATA_FLAG && FORCE_NVME_FLAG)
         || (FORCE_ATA_PIO_FLAG && FORCE_ATA_DMA_FLAG && FORCE_ATA_UDMA_FLAG)
         || (FORCE_ATA_PIO_FLAG && FORCE_ATA_DMA_FLAG)
         || (FORCE_ATA_PIO_FLAG && FORCE_ATA_UDMA_FLAG)
@@ -688,6 +690,15 @@ int32_t main(int argc, char *argv[])
                 printf("\tForcing ATA Drive\n");
             }
             deviceList[deviceIter].drive_info.drive_type = ATA_DRIVE;
+        }
+
+        if (FORCE_NVME_FLAG)
+        {
+            if (VERBOSITY_QUIET < toolVerbosity)
+            {
+                printf("\tForcing NVME Drive\n");
+            }
+            deviceList[deviceIter].drive_info.drive_type = NVME_DRIVE;
         }
 
         if (FORCE_ATA_PIO_FLAG)

--- a/utils/C/openSeaChest/openSeaChest_Security.c
+++ b/utils/C/openSeaChest/openSeaChest_Security.c
@@ -43,7 +43,7 @@
 //  Global Variables  //
 ////////////////////////
 const char *util_name = "openSeaChest_Security";
-const char *buildVersion = "3.3.0";
+const char *buildVersion = "3.4.0";
 
 typedef enum _eSeaChestSecurityExitCodes
 {
@@ -905,6 +905,8 @@ int32_t main(int argc, char *argv[])
     }
         
     if ((FORCE_SCSI_FLAG && FORCE_ATA_FLAG)
+	|| (FORCE_SCSI_FLAG && FORCE_NVME_FLAG)
+	|| (FORCE_ATA_FLAG && FORCE_NVME_FLAG)
         || (FORCE_ATA_PIO_FLAG && FORCE_ATA_DMA_FLAG && FORCE_ATA_UDMA_FLAG)
         || (FORCE_ATA_PIO_FLAG && FORCE_ATA_DMA_FLAG)
         || (FORCE_ATA_PIO_FLAG && FORCE_ATA_UDMA_FLAG)
@@ -1178,6 +1180,15 @@ int32_t main(int argc, char *argv[])
                 printf("\tForcing ATA Drive\n");
             }
             deviceList[deviceIter].drive_info.drive_type = ATA_DRIVE;
+        }
+
+        if (FORCE_NVME_FLAG)
+        {
+            if (VERBOSITY_QUIET < toolVerbosity)
+            {
+                printf("\tForcing NVME Drive\n");
+            }
+            deviceList[deviceIter].drive_info.drive_type = NVME_DRIVE;
         }
 
         if (FORCE_ATA_PIO_FLAG)

--- a/utils/C/openSeaChest/openSeaChest_ZBD.c
+++ b/utils/C/openSeaChest/openSeaChest_ZBD.c
@@ -29,7 +29,7 @@
 //  Global Variables  //
 ////////////////////////
 const char *util_name = "openSeaChest_ZBD";
-const char *buildVersion = "2.2.2";
+const char *buildVersion = "2.3.0";
 
 ////////////////////////////
 //  functions to declare  //
@@ -525,6 +525,8 @@ int32_t main(int argc, char *argv[])
     }
 
     if ((FORCE_SCSI_FLAG && FORCE_ATA_FLAG)
+	|| (FORCE_SCSI_FLAG && FORCE_NVME_FLAG)
+	|| (FORCE_ATA_FLAG && FORCE_NVME_FLAG)
         || (FORCE_ATA_PIO_FLAG && FORCE_ATA_DMA_FLAG && FORCE_ATA_UDMA_FLAG)
         || (FORCE_ATA_PIO_FLAG && FORCE_ATA_DMA_FLAG)
         || (FORCE_ATA_PIO_FLAG && FORCE_ATA_UDMA_FLAG)
@@ -783,6 +785,15 @@ int32_t main(int argc, char *argv[])
                 printf("\tForcing ATA Drive\n");
             }
             deviceList[deviceIter].drive_info.drive_type = ATA_DRIVE;
+        }
+
+        if (FORCE_NVME_FLAG)
+        {
+            if (VERBOSITY_QUIET < toolVerbosity)
+            {
+                printf("\tForcing NVME Drive\n");
+            }
+            deviceList[deviceIter].drive_info.drive_type = NVME_DRIVE;
         }
 
         if (FORCE_ATA_PIO_FLAG)


### PR DESCRIPTION
NVMe devices are detected through the `nvme` prefix, which can be unreliable and require explicit specification. For one of our use cases, we have nvme ioctl compatible devices show up under names outside of /dev/nvme* .The ability to override disk type is already available for ata and scsi within openseachest. smartctl also has an option to force the NVMe protocol using `smartctl -d nvme /dev/sdX`, so it would be nice to have the same flag for NVMe devices in openSeaChest, similar to other protocols.