### PR TITLE
bug: Removing duplicate output for depop time

### DIFF
--- a/utils/C/openSeaChest/openSeaChest_Format.c
+++ b/utils/C/openSeaChest/openSeaChest_Format.c
@@ -37,7 +37,7 @@
 //  Global Variables  //
 ////////////////////////
 const char* util_name    = "openSeaChest_Format";
-const char* buildVersion = "3.4.0";
+const char* buildVersion = "3.4.1";
 
 ////////////////////////////
 //  functions to declare  //
@@ -1426,7 +1426,6 @@ int main(int argc, char* argv[])
                                                                           &depopElementID, &maxDepop, &currentDepop,
                                                                           elementList))
                         {
-                            printf("Depop time (Dec/Hex): %" PRIu64 "/%" PRIX64 "h\n", depopTime, depopTime);
                             show_Physical_Element_Descriptors_2(numberOfDescriptors, elementList, depopTime,
                                                                 depopElementID, maxDepop, currentDepop);
                         }


### PR DESCRIPTION
A debug message was left in from the last round of updates to depopulate and repopulate to confirm the value being passed back.
This removes the debug output from the utility

[Fixes Seagate/openSeaChest#215]