### PR TITLE
feat: add `showLbaStatus` to support LBA Status Log

### DIFF
--- a/include/openseachest_util_options.h
+++ b/include/openseachest_util_options.h
@@ -2352,6 +2352,14 @@ extern "C"
         DEPOP_MAX_LBA_LONG_OPT_STRING, required_argument, M_NULLPTR, 0                                                 \
     }
 
+#define SHOW_LBA_STATUS_FLAG            showLbaStatus
+#define SHOW_LBA_STATUS_VAR             getOptBool SHOW_LBA_STATUS_FLAG = goFalse;
+#define SHOW_LBA_STATUS_LONG_OPT_STRING "showLbaStatus"
+#define SHOW_LBA_STATUS_LONG_OPT                                                                          \
+    {                                                                                                                  \
+        SHOW_LBA_STATUS_LONG_OPT_STRING, no_argument, &SHOW_LBA_STATUS_FLAG, goTrue          \
+    }
+
 // TCG Band/Range info
 #define SHOW_LOCKED_REGIONS                 showLockedRegions
 #define SHOW_LOCKED_REGIONS_VAR             getOptBool SHOW_LOCKED_REGIONS = goFalse;
@@ -4831,6 +4839,8 @@ extern "C"
     void print_Depop_MaxLBA_Help(bool shortHelp);
 
     void print_Repopulate_Elements_Help(bool shortHelp);
+
+    void print_Show_Lba_Status_Help(bool shortHelp);
 
     void print_Show_Locked_Regions_Help(bool shortHelp);
 

--- a/src/openseachest_util_options.c
+++ b/src/openseachest_util_options.c
@@ -3705,6 +3705,17 @@ void print_Repopulate_Elements_Help(bool shortHelp)
     }
 }
 
+void print_Show_Lba_Status_Help(bool shortHelp)
+{
+    printf("\t--%s\n", SHOW_LBA_STATUS_LONG_OPT_STRING);
+    if (!shortHelp)
+    {
+        print_str("\t\tUse this option to see range & status of\n");
+        print_str("\t\tLBAs inside a drive.\n");
+        print_str("\n");
+    }
+}
+
 void print_Show_Locked_Regions_Help(bool shortHelp)
 {
     printf("\t--%s\n", SHOW_LOCKED_REGIONS_LONG_OPT_STRING);

--- a/utils/C/openSeaChest/openSeaChest_Format.c
+++ b/utils/C/openSeaChest/openSeaChest_Format.c
@@ -107,6 +107,7 @@ int main(int argc, char* argv[])
     REMOVE_PHYSICAL_ELEMENT_MOD_ZONES_VAR
     REPOPULATE_ELEMENTS_VAR
     DEPOP_MAX_LBA_VAR
+    SHOW_LBA_STATUS_VAR
     NVM_FORMAT_VARS
     NVM_FORMAT_OPTION_VARS
 #if defined(ENABLE_CSMI)
@@ -167,6 +168,7 @@ int main(int argc, char* argv[])
         REMOVE_PHYSICAL_ELEMENT_LONG_OPT,
         REMOVE_PHYSICAL_ELEMENT_MOD_ZONES_LONG_OPT,
         REPOPULATE_ELEMENTS_LONG_OPT,
+        SHOW_LBA_STATUS_LONG_OPT,
         DEPOP_MAX_LBA_LONG_OPT,
         NVM_FORMAT_LONG_OPT,
         NVM_FORMAT_OPTIONS_LONG_OPTS,
@@ -897,7 +899,7 @@ int main(int argc, char* argv[])
           // check for other tool specific options here
           || FORMAT_UNIT_FLAG || DISPLAY_LBA_FLAG || (PROGRESS_CHAR != M_NULLPTR) || SHOW_FORMAT_STATUS_LOG_FLAG ||
           SET_SECTOR_SIZE_FLAG || SHOW_SUPPORTED_FORMATS_FLAG || SHOW_PHYSICAL_ELEMENT_STATUS_FLAG ||
-          REMOVE_PHYSICAL_ELEMENT_FLAG > 0 || REPOPULATE_ELEMENTS_FLAG || NVM_FORMAT_FLAG ||
+          REMOVE_PHYSICAL_ELEMENT_FLAG > 0 || REPOPULATE_ELEMENTS_FLAG || NVM_FORMAT_FLAG || SHOW_LBA_STATUS_FLAG ||
           REMOVE_PHYSICAL_ELEMENT_MOD_ZONES_FLAG > 0
           ))
     {
@@ -2073,6 +2075,60 @@ int main(int argc, char* argv[])
             }
         }
 
+        if (SHOW_LBA_STATUS_FLAG)
+        {
+            uint64_t numberOfDescriptors = UINT64_C(0);
+            eReturnValues getLbaStatusRet = get_Number_Of_LBA_Status_Descriptors(&deviceList[deviceIter], &numberOfDescriptors);
+            if (getLbaStatusRet == SUCCESS && numberOfDescriptors > 0)
+            {
+                ptrLbaStatusDescriptor descriptorList = M_REINTERPRET_CAST(
+                    ptrLbaStatusDescriptor, safe_malloc(numberOfDescriptors * sizeof(lbaStatusDescriptor)));
+                if (descriptorList != M_NULLPTR)
+                {
+                    safe_memset(descriptorList, numberOfDescriptors * sizeof(lbaStatusDescriptor), 0,
+                                numberOfDescriptors * sizeof(lbaStatusDescriptor));
+                    if (SUCCESS == get_LBA_Status_Descriptors(&deviceList[deviceIter], numberOfDescriptors,
+                                                                        descriptorList))
+                    {
+                        show_LBA_Status_Descriptors(numberOfDescriptors, descriptorList);
+                    }
+                    else
+                    {
+                        if (VERBOSITY_QUIET < toolVerbosity)
+                        {
+                            print_str("Failed to get physical element status.\n");
+                        }
+                        exitCode = UTIL_EXIT_OPERATION_FAILURE;
+                    }
+                    safe_free_lba_status(&descriptorList);
+                }
+                else
+                {
+                    if (VERBOSITY_QUIET < toolVerbosity)
+                    {
+                        print_str("Unable to allocate memory for LBA Status descriptors\n");
+                    }
+                    exitCode = UTIL_EXIT_OPERATION_FAILURE;
+                }
+            }
+            else if (getLbaStatusRet == SUCCESS)
+            {
+                if (VERBOSITY_QUIET < toolVerbosity)
+                {
+                    print_str("No LBA Status descriptor present on this device.\n");
+                }
+                exitCode = UTIL_EXIT_OPERATION_NOT_SUPPORTED;
+            }
+            else
+            {
+                if (VERBOSITY_QUIET < toolVerbosity)
+                {
+                    print_str("The LBA Status feature is not supported on this device.\n");
+                }
+                exitCode = UTIL_EXIT_OPERATION_NOT_SUPPORTED;
+            }
+        }
+
         if (PROGRESS_CHAR != M_NULLPTR)
         {
             eReturnValues result = UNKNOWN;
@@ -2188,6 +2244,7 @@ void utility_Usage(bool shortUsage)
     printf("\t%s -d %s --%s 2\n", util_name, deviceHandleExample, REMOVE_PHYSICAL_ELEMENT_LONG_OPT_STRING);
     printf("\t%s -d %s --%s 2\n", util_name, deviceHandleExample, REMOVE_PHYSICAL_ELEMENT_MOD_ZONES_LONG_OPT_STRING);
     printf("\t%s -d %s --%s\n", util_name, deviceHandleExample, REPOPULATE_ELEMENTS_LONG_OPT_STRING);
+    printf("\t%s -d %s --%s\n", util_name, deviceHandleExample, SHOW_LBA_STATUS_LONG_OPT_STRING);
     printf("\t%s -d %s --%s\n", util_name, deviceHandleExample, SHOW_SUPPORTED_FORMATS_LONG_OPT_STRING);
     printf("\t%s -d %s --%s\n", util_name, deviceHandleExample, SHOW_FORMAT_STATUS_LOG_LONG_OPT_STRING);
     printf("\t%s -d %s --%s current --%s\n", util_name, deviceHandleExample, FORMAT_UNIT_LONG_OPT_STRING,
@@ -2261,6 +2318,7 @@ void utility_Usage(bool shortUsage)
     // multiple interfaces
     print_Depop_MaxLBA_Help(shortUsage);
     print_Show_Physical_Element_Status_Help(shortUsage);
+    print_Show_Lba_Status_Help(shortUsage);
     print_Show_Supported_Formats_Help(shortUsage);
     // SATA Only Options
     // print_str("\n\tSATA Only:\n\n");


### PR DESCRIPTION
LBA Status Log is a existing log (19h) but with new additions to support regen feature.

There is a presentation on OCP Summit introducing LBA Status Log here: https://www.youtube.com/watch?v=RHBk9i4XSPg

Currently only SATA is implemented since I don't have SAS drives yet. The new functions are created following existing functions for showPhysicalElementStatus.

https://github.com/Seagate/opensea-operations/pull/38 needs to be bumped as dependency of this commit.

Example output:

<img width="962" height="314" alt="putty_yUJ4tVwBdO" src="https://github.com/user-attachments/assets/bdfdd047-63e5-48da-9072-f62dc9bd803c" />
