### PR TITLE
quick: improvement to power consumption control

### DIFF
--- a/include/openseachest_util_options.h
+++ b/include/openseachest_util_options.h
@@ -1082,11 +1082,13 @@ extern "C"
 #define SET_POWER_CONSUMPTION_VALUE              powerConsumptionIdentifierValue
 #define SET_POWER_CONSUMPTION_WATTS_VALUE        powerConsumptionWatts
 #define SET_POWER_CONSUMPTION_DEFAULT_FLAG       setDefaultPowerConsumption
+#define SET_POWER_CONSUMPTION_DISABLED_FLAG      setDisabledPowerConsumption
 #define SET_POWER_CONSUMPTION_ACTIVE_LEVEL_VALUE powerConsumptionActiveLevel
 #define SET_POWER_CONSUMPTION_VARS                                                                                     \
     bool    SET_POWER_CONSUMPTION_FLAG               = false;                                                          \
     uint8_t SET_POWER_CONSUMPTION_VALUE              = UINT8_C(0);                                                     \
     bool    SET_POWER_CONSUMPTION_DEFAULT_FLAG       = false;                                                          \
+    bool    SET_POWER_CONSUMPTION_DISABLED_FLAG      = false;                                                          \
     uint8_t SET_POWER_CONSUMPTION_ACTIVE_LEVEL_VALUE = UINT8_C(0);                                                     \
     double  SET_POWER_CONSUMPTION_WATTS_VALUE        = 0.0;
 #define SET_POWER_CONSUMPTION_LONG_OPT_STRING "setPowerConsumption"

--- a/src/openseachest_util_options.c
+++ b/src/openseachest_util_options.c
@@ -1647,7 +1647,7 @@ void print_Trim_Unmap_Range_Help(bool shortHelp)
 
 void print_Show_Power_Consumption_Help(bool shortHelp)
 {
-    printf("\t--%s\t(SAS Only)\n", SHOW_POWER_CONSUMPTION_LONG_OPT_STRING);
+    printf("\t--%s\n", SHOW_POWER_CONSUMPTION_LONG_OPT_STRING);
     if (!shortHelp)
     {
         print_str("\t\tThis option will show the power consumption\n");
@@ -1660,7 +1660,7 @@ void print_Show_Power_Consumption_Help(bool shortHelp)
 
 void print_Set_Power_Consumption_Help(bool shortHelp)
 {
-    printf("\t--%s [default | highest | intermediate | lowest | watt value]\t(SAS Only) \n",
+    printf("\t--%s [default | highest | intermediate | lowest | disabled | watt value]\n",
            SET_POWER_CONSUMPTION_LONG_OPT_STRING);
     if (!shortHelp)
     {
@@ -1671,6 +1671,7 @@ void print_Set_Power_Consumption_Help(bool shortHelp)
         print_str("\t\t-highest - sets the active level to \"highest\"\n");
         print_str("\t\t-intermediate - sets the active level to \"intermediate\"\n");
         print_str("\t\t-lowest - sets the active level to \"lowest\"\n");
+        print_str("\t\t-disabled - sets power consumption control to disabled (SATA Only)\n");
         print_str("\t\t-watt value - sets the device to a nearest watt value\n");
         print_str("\t\tless than or equal to the value entered.\n");
         print_str("\t\tPower consumption watt values are listed with the\n");

--- a/utils/C/openSeaChest/openSeaChest_PowerControl.c
+++ b/utils/C/openSeaChest/openSeaChest_PowerControl.c
@@ -324,6 +324,10 @@ int main(int argc, char* argv[])
                 {
                     SET_POWER_CONSUMPTION_ACTIVE_LEVEL_VALUE = 3;
                 }
+                else if (strcmp(optarg, "disabled") == 0)
+                {
+                    SET_POWER_CONSUMPTION_DISABLED_FLAG = true;
+                }
                 else
                 {
                     if (!get_And_Validate_Double_Input(optarg, M_NULLPTR, ALLOW_UNIT_NONE,
@@ -2509,7 +2513,8 @@ int main(int argc, char* argv[])
         if (SET_POWER_CONSUMPTION_FLAG)
         {
             eReturnValues pcRet = SUCCESS;
-            if (SET_POWER_CONSUMPTION_ACTIVE_LEVEL_VALUE == PC_ACTIVE_LEVEL_IDENTIFIER)
+            if (!SET_POWER_CONSUMPTION_DEFAULT_FLAG && !SET_POWER_CONSUMPTION_DISABLED_FLAG &&
+                SET_POWER_CONSUMPTION_ACTIVE_LEVEL_VALUE == PC_ACTIVE_LEVEL_IDENTIFIER)
             {
                 pcRet = map_Watt_Value_To_Power_Consumption_Identifier(
                     &deviceList[deviceIter], SET_POWER_CONSUMPTION_WATTS_VALUE, &SET_POWER_CONSUMPTION_VALUE);
@@ -2517,7 +2522,8 @@ int main(int argc, char* argv[])
             if (pcRet == SUCCESS)
             {
                 switch (set_Power_Consumption(&deviceList[deviceIter], SET_POWER_CONSUMPTION_ACTIVE_LEVEL_VALUE,
-                                              SET_POWER_CONSUMPTION_VALUE, SET_POWER_CONSUMPTION_DEFAULT_FLAG, false))
+                                              SET_POWER_CONSUMPTION_VALUE, SET_POWER_CONSUMPTION_DEFAULT_FLAG,
+                                              SET_POWER_CONSUMPTION_DISABLED_FLAG))
                 {
                 case SUCCESS:
                     if (VERBOSITY_QUIET < toolVerbosity)
@@ -3291,6 +3297,8 @@ void utility_Usage(bool shortUsage)
     print_Standby_Y_Help(shortUsage);
     print_Standby_Z_Help(shortUsage);
     print_Transition_Power_Help(shortUsage);
+    print_Set_Power_Consumption_Help(shortUsage);
+    print_Show_Power_Consumption_Help(shortUsage);
 
     // SATA Only Options
     print_str("\n\tSATA Only:\n\t=========\n");
@@ -3306,8 +3314,6 @@ void utility_Usage(bool shortUsage)
     print_SAS_Phy_Help(shortUsage);
     print_SAS_Phy_Partial_Help(shortUsage);
     print_SAS_Phy_Slumber_Help(shortUsage);
-    print_Set_Power_Consumption_Help(shortUsage);
-    print_Show_Power_Consumption_Help(shortUsage);
     // NVMe Only
     print_str("\n\tNVMe Only:\n\t=========\n");
     print_Show_NVM_Power_States_Help(shortUsage);


### PR DESCRIPTION
1. allow disable power consumption control & help text update
2. skip watt value mapping when unnecessary to fix restore to default not work when ATA log 59h is empty
3. move help text from SAS only to common section