### PR TITLE
Add zizmor security scanning and improve CI/CD security

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,3 +13,5 @@ updates:
     directory: "/.github/workflows"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: MPL-2.0
 name: C/C++ CI
 
+permissions: {}
+
 on:
   push:
     branches: [ develop, master, release/*, feature/*, hotfix/* ]
@@ -50,18 +52,23 @@ jobs:
       with:
         egress-policy: audit
 
-    - uses: actions/checkout@v6.0.2
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       continue-on-error: true  # rsync code 24: harmless cleanup-phase race during VM setup
       with:
+        persist-credentials: false
         submodules: recursive
 
     - name: Escape backslash in branch name
       run: echo "BRANCH_NAME=$(echo ${GITHUB_REF#refs/heads/} | tr / -)" >> $GITHUB_ENV
 
     - name: Set release name
+      id: release_vars
+      env:
+        RELEASE_NAME: ${{ matrix.config.release_name }}
       run: |
-        DESTDIR="openSeaChest-${BRANCH_NAME}-${{ matrix.config.release_name }}"
+        DESTDIR="openSeaChest-${BRANCH_NAME}-${RELEASE_NAME}"
         echo "DESTDIR=${DESTDIR}" >> $GITHUB_ENV
+        echo "destdir=${DESTDIR}" >> $GITHUB_OUTPUT
 
     - name: Add Mingw-w64 to path
       if: startsWith(matrix.config.name, 'Windows GCC')
@@ -73,22 +80,30 @@ jobs:
 
     - name: make
       working-directory: ${{ matrix.config.builddir }}
+      env:
+        MAKEFILE_NAME: ${{ matrix.config.makefile }}
       run: |
-        make release -f ${{ matrix.config.makefile }}
+        make release -f "$MAKEFILE_NAME"
 
     - name: Packing release
       env:
+        DESTDIR: ${{ steps.release_vars.outputs.destdir }}
         ARCHIVE_EXT: ${{ matrix.config.release_extension }}
+        RELEASE_BUILD_DIR: ${{ matrix.config.builddir }}
       run: |
         mkdir build
         cd build
-        ${{ matrix.config.archive_command }} "${DESTDIR}${ARCHIVE_EXT}" ../${{ matrix.config.builddir }}/openseachest_exes
+        if [[ "$ARCHIVE_EXT" == ".zip" ]]; then
+          7z a -tzip -mmt "${DESTDIR}${ARCHIVE_EXT}" "../${RELEASE_BUILD_DIR}/openseachest_exes"
+        else
+          tar cvfJ "${DESTDIR}${ARCHIVE_EXT}" "../${RELEASE_BUILD_DIR}/openseachest_exes"
+        fi
 
     - name: Uploading artifacts
-      uses: actions/upload-artifact@v7.0.0
+      uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
       with:
-        name: ${{ format('{0}', env.DESTDIR) }}
-        path: ${{ format('./build/{0}{1}', env.DESTDIR, matrix.config.release_extension) }}
+        name: ${{ steps.release_vars.outputs.destdir }}
+        path: ${{ format('./build/{0}{1}', steps.release_vars.outputs.destdir, matrix.config.release_extension) }}
 
     # - name: Publish release
     #   if: ${{ startsWith(github.ref, 'refs/tags/v') && matrix.config.publish_release }}

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -6,6 +6,8 @@
 # or to provide custom queries or build logic.
 name: "CodeQL"
 
+permissions: {}
+
 on:
   push:
     branches: [develop, master]
@@ -24,9 +26,9 @@ jobs:
     name: Analyze
     runs-on: ${{ matrix.config.os }}
     permissions:
-      security-events: write
+      security-events: write # Upload CodeQL SARIF results to code scanning.
       contents: read
-      actions: read
+      actions: read # Allow CodeQL to inspect workflow and action metadata.
     strategy:
       fail-fast: false
       matrix:
@@ -76,9 +78,10 @@ jobs:
         egress-policy: audit
 
     - name: Checkout repository
-      uses: actions/checkout@v6.0.2
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       continue-on-error: true  # rsync code 24: harmless cleanup-phase race during VM setup
       with:
+        persist-credentials: false
         # We must fetch at least the immediate parents so that if this is
         # a pull request then we can checkout the head.
         fetch-depth: 2
@@ -86,7 +89,7 @@ jobs:
 
     - name: Settings vars for MSVC
       if: startsWith(matrix.config.name, 'Windows MSVC')
-      uses: ilammy/msvc-dev-cmd@v1
+      uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
       with:
         arch: ${{ matrix.config.arch }}
 
@@ -97,7 +100,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v4
+      uses: github/codeql-action/init@c10b8064de6f491fea524254123dbe5e09572f13 # v4.35.1
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -118,7 +121,7 @@ jobs:
     #    uses a compiled language
 
     - name: Setup pip cache
-      uses: actions/cache@v5.0.0
+      uses: actions/cache@a7833574556fa59680c1b7cb190c1735db73ebf0 # v5.0.0
       with:
         path: |
           ~/.cache/pip
@@ -134,10 +137,16 @@ jobs:
       env:
         CC: ${{ matrix.config.cc }}
         CXX: ${{ matrix.config.cxx }}
+        MESON_OPTS: ${{ matrix.config.meson_opts }}
       run: |
         pip install meson ninja
         $prefix = Join-Path $env:GITHUB_WORKSPACE 'install'
-        meson setup build --prefix "$prefix" -Dmandir=man -Dbindir=bin ${{ matrix.config.meson_opts }} --buildtype=release
+        $mesonArgs = @('setup', 'build', '--prefix', $prefix, '-Dmandir=man', '-Dbindir=bin')
+        if ($env:MESON_OPTS) {
+          $mesonArgs += ($env:MESON_OPTS -split ' ')
+        }
+        $mesonArgs += '--buildtype=release'
+        meson @mesonArgs
         meson install -C build
 
     - name: Install Meson and Ninja and Build (Github runners - non-MSVC)
@@ -146,10 +155,17 @@ jobs:
       env:
         CC: ${{ matrix.config.cc }}
         CXX: ${{ matrix.config.cxx }}
+        MESON_OPTS: ${{ matrix.config.meson_opts }}
       run: |
         pip install meson ninja
-        meson setup build --prefix "$GITHUB_WORKSPACE/install" -Dmandir=man -Dbindir=bin ${{ matrix.config.meson_opts }} --buildtype=release
+        meson_args=(setup build --prefix "$GITHUB_WORKSPACE/install" -Dmandir=man -Dbindir=bin)
+        if [[ -n "$MESON_OPTS" ]]; then
+          read -r -a extra_meson_args <<< "$MESON_OPTS"
+          meson_args+=("${extra_meson_args[@]}")
+        fi
+        meson_args+=(--buildtype=release)
+        meson "${meson_args[@]}"
         meson install -C build
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v4
+      uses: github/codeql-action/analyze@c10b8064de6f491fea524254123dbe5e09572f13 # v4.35.1

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,17 +1,21 @@
 # SPDX-License-Identifier: MPL-2.0
 name: Dependency Review
 
+permissions: {}
+
 on:
   pull_request:
     branches: [ develop ]
 
-permissions:
-  contents: read
-  pull-requests: write
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
 
 jobs:
   dependency-review:
+    name: Dependency review
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.14.1
@@ -19,10 +23,12 @@ jobs:
           egress-policy: audit
 
       - name: Checkout Repository
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Dependency Review
-        uses: actions/dependency-review-action@v4
+        uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4.9.0
         with:
           fail-on-severity: high
           warn-on-openssf-scorecard-level: 3

--- a/.github/workflows/flawfinder.yml
+++ b/.github/workflows/flawfinder.yml
@@ -5,6 +5,8 @@
 
 name: flawfinder
 
+permissions: {}
+
 on:
   push:
     branches: [ "develop", "master", "release/*" ]
@@ -14,14 +16,17 @@ on:
   schedule:
     - cron: '39 23 * * 1'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+
 jobs:
   flawfinder:
     name: Flawfinder
     runs-on: ubuntu-latest
     permissions:
-      actions: read
+      actions: read # Allow the workflow to inspect action metadata during analysis.
       contents: read
-      security-events: write
+      security-events: write # Upload flawfinder SARIF results to code scanning.
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.14.1
@@ -29,7 +34,9 @@ jobs:
           egress-policy: audit
 
       - name: Checkout code
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: flawfinder_scan
         uses: david-a-wheeler/flawfinder@c57197cd6061453f10a496f30a732bc1905918d1
@@ -38,6 +45,6 @@ jobs:
           output: 'flawfinder_results.sarif'
 
       - name: Upload analysis results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action/upload-sarif@c10b8064de6f491fea524254123dbe5e09572f13 # v4.35.1
         with:
           sarif_file: ${{github.workspace}}/flawfinder_results.sarif

--- a/.github/workflows/meson.yml
+++ b/.github/workflows/meson.yml
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: MPL-2.0
 name: CI for meson build
 
+permissions: {}
+
 on:
   push:
     branches: [ develop, master, release/*, feature/*, hotfix/* ]
@@ -19,8 +21,7 @@ jobs:
     container: ${{ matrix.config.image }}
     timeout-minutes: 120
     permissions:
-      contents: write
-      packages: read
+      contents: write # Create and update tagged release assets from build jobs.
     strategy:
       fail-fast: false # so that if one config fails, other won't be cancelled automatically
       matrix:
@@ -521,14 +522,15 @@ jobs:
     #   with:
     #     egress-policy: audit
 
-    - uses: actions/checkout@v6.0.2
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       continue-on-error: true  # rsync code 24: harmless cleanup-phase race during VM setup
       with:
+        persist-credentials: false
         submodules: recursive
 
     - name: Setup MSYS2
       if: matrix.config.msys2_msystem != ''
-      uses: msys2/setup-msys2@v2
+      uses: msys2/setup-msys2@cafece8e6baf9247cf9b1bf95097b0b983cc558d # v2.31.0
       with:
         msystem: ${{ matrix.config.msys2_msystem }}
         update: true
@@ -542,14 +544,17 @@ jobs:
 
     - name: Settings vars for MSVC
       if: startsWith(matrix.config.name, 'Windows MSVC')
-      uses: ilammy/msvc-dev-cmd@v1
+      uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
       with:
         arch: ${{ matrix.config.arch }}
 
     - name: Get latest LLVM version
+      id: llvm_release
       if: startsWith(matrix.config.name, 'Windows Clang')
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        $headers = @{ Authorization = 'Bearer ${{ secrets.GITHUB_TOKEN }}' }
+        $headers = @{ Authorization = "Bearer $env:GH_TOKEN" }
         $latestRelease = Invoke-WebRequest -Headers $headers 'https://api.github.com/repos/llvm/llvm-project/releases/latest'
         $releaseData = $latestRelease.Content | ConvertFrom-Json
         $assets = $releaseData.assets | Where-Object { $_.name -like "*win64.exe" }
@@ -558,6 +563,8 @@ jobs:
           $downloadUrl = $assets.browser_download_url
           echo "LLVM_RELID=$($releaseData.id)" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
           echo "LLVM_DOWNLOAD_URL=$downloadUrl" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          echo "relid=$($releaseData.id)" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+          echo "download_url=$downloadUrl" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
         } else {
           Write-Host "No current Windows build available for the latest release. Searching for previous releases..."
           $releases = Invoke-WebRequest -Headers $headers 'https://api.github.com/repos/llvm/llvm-project/releases'
@@ -569,6 +576,8 @@ jobs:
               $downloadUrl = $assets.browser_download_url
               echo "LLVM_RELID=$($release.id)" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
               echo "LLVM_DOWNLOAD_URL=$downloadUrl" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+              echo "relid=$($release.id)" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+              echo "download_url=$downloadUrl" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
               $found = $true
               break
             }
@@ -581,35 +590,45 @@ jobs:
         }
 
     - name: Restore LLVM from cache
-      if: startsWith(matrix.config.name, 'Windows Clang')
+      if: startsWith(matrix.config.name, 'Windows Clang') && steps.llvm_release.outputs.relid != ''
       id: llvm-cache
-      uses: actions/cache@v5
+      uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
       with:
         path: C:/Program Files/LLVM
-        key: 'llvm-llvm-project-relid-${{ env.LLVM_RELID }}'
+        key: llvm-llvm-project-relid-${{ steps.llvm_release.outputs.relid }}
 
     - name: Downloading latest clang for Windows
-      if: ${{ steps.llvm-cache.outputs.cache-hit != 'true' && startsWith(matrix.config.name, 'Windows Clang') }}
+      if: startsWith(matrix.config.name, 'Windows Clang') && steps.llvm-cache.outputs.cache-hit != 'true'
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        $headers = @{ Authorization = 'Bearer ${{ secrets.GITHUB_TOKEN }}' }
-        Invoke-WebRequest -Headers $headers -OutFile "LLVM.exe" ((Invoke-WebRequest -Headers $headers "https://api.github.com/repos/llvm/llvm-project/releases/$($env:LLVM_RELID)").Content | ConvertFrom-Json | Select-Object -ExpandProperty assets | Where -Property name -Like "*win64.exe" | Select-Object -First 1).browser_download_url
+        $headers = @{ Authorization = "Bearer $env:GH_TOKEN" }
+        Invoke-WebRequest -Headers $headers -OutFile "LLVM.exe" $env:LLVM_DOWNLOAD_URL
         7z x LLVM.exe -y -o"C:/Program Files/LLVM"
 
     - name: Escape backslash in branch name
       shell: bash
-      run: echo "BRANCH_NAME=$(echo ${{ github.ref_name }} | tr / -)" >> $GITHUB_ENV
+      env:
+        REF_NAME: ${{ github.ref_name }}
+      run: echo "BRANCH_NAME=$(echo "$REF_NAME" | tr / -)" >> $GITHUB_ENV
 
     - name: Set release name
+      id: release_vars
+      env:
+        RELEASE_NAME: ${{ matrix.config.release_name }}
       run: |
-        DESTDIR="openSeaChest-${BRANCH_NAME}-${{ matrix.config.release_name }}"
+        DESTDIR="openSeaChest-${BRANCH_NAME}-${RELEASE_NAME}"
         echo "DESTDIR=${DESTDIR}" >> $GITHUB_ENV
+        echo "destdir=${DESTDIR}" >> $GITHUB_OUTPUT
       shell: bash
 
     - name: Set SOURCE_DATE_EPOCH for Reproducible Builds
       shell: bash
+      env:
+        MATRIX_IMAGE: ${{ matrix.config.image }}
       run: |
         # Fix git ownership in containers
-        if [[ -n "${{ matrix.config.image }}" ]]; then
+        if [[ -n "$MATRIX_IMAGE" ]]; then
           git config --global --add safe.directory "$GITHUB_WORKSPACE"
         fi
 
@@ -623,6 +642,7 @@ jobs:
       shell: bash
       env:
         DESTDIR: ${{ env.DESTDIR }}
+        MESON_OPTS: ${{ matrix.config.meson_opts }}
       run: |
         # Install GNU tar for reproducible archives (BusyBox tar lacks --sort option)
         if command -v apk &> /dev/null; then
@@ -639,7 +659,13 @@ jobs:
           zypper install -y tar
         fi
 
-        meson setup build -Dprefix=/ -Dmandir=/man -Dbindir=/ ${{ matrix.config.meson_opts }} --buildtype=release
+        meson_args=(setup build -Dprefix=/ -Dmandir=/man -Dbindir=/)
+        if [[ -n "$MESON_OPTS" ]]; then
+          read -r -a extra_meson_args <<< "$MESON_OPTS"
+          meson_args+=("${extra_meson_args[@]}")
+        fi
+        meson_args+=(--buildtype=release)
+        meson "${meson_args[@]}"
         meson install -C build
 
     - name: Install Meson and Ninja and Build (MSYS2)
@@ -648,8 +674,15 @@ jobs:
       env:
         CC: ${{ matrix.config.cc }}
         CXX: ${{ matrix.config.cxx }}
+        MESON_OPTS: ${{ matrix.config.meson_opts }}
       run: |
-        meson setup build -Dprefix=/ -Dmandir=/man -Dbindir=/ ${{ matrix.config.meson_opts }} --buildtype=release
+        meson_args=(setup build -Dprefix=/ -Dmandir=/man -Dbindir=/)
+        if [[ -n "$MESON_OPTS" ]]; then
+          read -r -a extra_meson_args <<< "$MESON_OPTS"
+          meson_args+=("${extra_meson_args[@]}")
+        fi
+        meson_args+=(--buildtype=release)
+        meson "${meson_args[@]}"
         meson install -C build
 
 
@@ -672,9 +705,15 @@ jobs:
       env:
         CC: ${{ matrix.config.cc }}
         CXX: ${{ matrix.config.cxx }}
+        MESON_OPTS: ${{ matrix.config.meson_opts }}
       run: |
         pip install meson ninja
-        meson setup build -Dprefix=/ -Dmandir=/man -Dbindir=/ ${{ matrix.config.meson_opts }} --buildtype=release
+        $mesonArgs = @('setup', 'build', '-Dprefix=/', '-Dmandir=/man', '-Dbindir=/')
+        if ($env:MESON_OPTS) {
+          $mesonArgs += ($env:MESON_OPTS -split ' ')
+        }
+        $mesonArgs += '--buildtype=release'
+        meson @mesonArgs
         meson install -C build
 
     - name: Install Meson and Ninja and Build (Github runners - non-MSVC)
@@ -683,14 +722,21 @@ jobs:
       env:
         CC: ${{ matrix.config.cc }}
         CXX: ${{ matrix.config.cxx }}
+        MESON_OPTS: ${{ matrix.config.meson_opts }}
       run: |
         pip install meson ninja
-        meson setup build -Dprefix=/ -Dmandir=/man -Dbindir=/ ${{ matrix.config.meson_opts }} --buildtype=release
+        meson_args=(setup build -Dprefix=/ -Dmandir=/man -Dbindir=/)
+        if [[ -n "$MESON_OPTS" ]]; then
+          read -r -a extra_meson_args <<< "$MESON_OPTS"
+          meson_args+=("${extra_meson_args[@]}")
+        fi
+        meson_args+=(--buildtype=release)
+        meson "${meson_args[@]}"
         meson install -C build
 
     - name: Install Meson and Ninja and Build (VMActions OmniOS)
       if: matrix.config.vm_actions == true && startsWith(matrix.config.name, 'VMActions OmniOS')
-      uses: vmactions/omnios-vm@v1
+      uses: vmactions/omnios-vm@68da93c6d9812b29fc90c5b5141b093f84a590fb # v1.2.7
       with:
         envs: 'DESTDIR'
         release: ${{ matrix.config.vm_release }}
@@ -711,7 +757,7 @@ jobs:
 
     - name: Install Meson and Ninja and Build (VMActions OpenIndiana)
       if: matrix.config.vm_actions == true && startsWith(matrix.config.name, 'VMActions OpenIndiana')
-      uses: vmactions/openindiana-vm@v1
+      uses: vmactions/openindiana-vm@0544593284f5c837f637097e278df86bf5bbab1e # v1.0.7
       with:
         envs: 'DESTDIR'
         release: ${{ matrix.config.vm_release }}
@@ -732,7 +778,7 @@ jobs:
 
     - name: Install Meson and Ninja and Build (VMActions Solaris)
       if: matrix.config.vm_actions == true && startsWith(matrix.config.name, 'VMActions Solaris')
-      uses: vmactions/solaris-vm@v1
+      uses: vmactions/solaris-vm@0a231b94365d1911cf62097ef342f6b30d95598f # v1.3.2
       with:
         envs: 'DESTDIR'
         release: ${{ matrix.config.vm_release }}
@@ -752,7 +798,7 @@ jobs:
 
     - name: Install Meson and Ninja and Build (VMActions FreeBSD)
       if: matrix.config.vm_actions == true && startsWith(matrix.config.name, 'VMActions FreeBSD')
-      uses: vmactions/freebsd-vm@v1
+      uses: vmactions/freebsd-vm@7ca82f79fe3078fecded6d3a2bff094995447bbd # v1.4.4
       with:
         envs: 'DESTDIR'
         release: ${{ matrix.config.vm_release }}
@@ -772,7 +818,7 @@ jobs:
 
     - name: Install Meson and Ninja and Build (VMActions DragonFlyBSD)
       if: matrix.config.vm_actions == true && startsWith(matrix.config.name, 'VMActions DragonFlyBSD')
-      uses: vmactions/dragonflybsd-vm@v1
+      uses: vmactions/dragonflybsd-vm@323497fa680c1856dd1ba5c4fd89182a9194f649 # v1.2.7
       with:
         envs: 'DESTDIR'
         release: ${{ matrix.config.vm_release }}
@@ -791,7 +837,7 @@ jobs:
 
     - name: Install Meson and Ninja and Build (VMActions OpenBSD)
       if: matrix.config.vm_actions == true && startsWith(matrix.config.name, 'VMActions OpenBSD')
-      uses: vmactions/openbsd-vm@v1
+      uses: vmactions/openbsd-vm@9004791062e748d95cc87e499e77485f91888ce1 # v1.3.8
       with:
         envs: 'DESTDIR'
         release: ${{ matrix.config.vm_release }}
@@ -812,7 +858,7 @@ jobs:
 
     - name: Install Meson and Ninja and Build (VMActions NetBSD)
       if: matrix.config.vm_actions == true && startsWith(matrix.config.name, 'VMActions NetBSD')
-      uses: vmactions/netbsd-vm@v1
+      uses: vmactions/netbsd-vm@ca7ff0556959998c82761c34ea0c3c99fa084c48 # v1.3.7
       with:
         envs: 'DESTDIR'
         release: ${{ matrix.config.vm_release }}
@@ -835,21 +881,25 @@ jobs:
 
     - name: Install Go for nfpm
       if: ${{ matrix.config.create_package }}
-      uses: actions/setup-go@v6
+      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
       with:
         go-version: 'stable'
         cache: false
 
     - name: Create packages
       if: ${{ matrix.config.create_package }}
-      working-directory: ${{ format('build/{0}', env.DESTDIR) }}
+      working-directory: ${{ format('build/{0}', steps.release_vars.outputs.destdir) }}
       shell: bash
+      env:
+        CROSS_COMPILER_ARCH: ${{ matrix.config.cross_compiler_arch }}
+        REF_NAME: ${{ github.ref_name }}
+        REF_FULL: ${{ github.ref }}
       run: |
         # Install nfpm
         go install github.com/goreleaser/nfpm/v2/cmd/nfpm@latest
 
         # Map cross_compiler_arch to Debian/RPM package arch
-        case "${{ matrix.config.cross_compiler_arch }}" in
+        case "$CROSS_COMPILER_ARCH" in
           x86_64) package_arch="amd64" ;;
           i686) package_arch="i386" ;;
           aarch64) package_arch="arm64" ;;
@@ -862,8 +912,8 @@ jobs:
         esac
 
         # Set version and arch
-        if [[ ${{ github.ref }} =~ ^refs/tags/v[0-9\.]+$ ]]; then
-          version=$(echo ${{ github.ref_name }} | tr -d 'v')
+        if [[ "$REF_FULL" =~ ^refs/tags/v[0-9\.]+$ ]]; then
+          version=$(echo "$REF_NAME" | tr -d 'v')
         else
           version=$(printf "%s-dev" $(date +'%y.%m.%d'))
         fi
@@ -876,8 +926,10 @@ jobs:
     - name: Set ownership of executables to root:root
       if: ${{ matrix.config.os != 'windows-latest' }}
       shell: bash
+      env:
+        MATRIX_IMAGE: ${{ matrix.config.image }}
       run: |
-        if [[ -z "${{ matrix.config.image }}" ]]; then
+        if [[ -z "$MATRIX_IMAGE" ]]; then
           sudo chown -R root:root build
         else
           chown -R root:root build
@@ -893,11 +945,14 @@ jobs:
 
     - name: Packing release
       env:
+        ARCHIVE_COMMAND: ${{ matrix.config.archive_command }}
         ARCHIVE_EXT: ${{ matrix.config.release_extension }}
+        TARGET_OS: ${{ matrix.config.os }}
+        MATRIX_IMAGE: ${{ matrix.config.image }}
       run: |
         cd build
         ls -la
-        if [[ "${{ matrix.config.os }}" != "windows-latest" ]]; then
+        if [[ "$TARGET_OS" != "windows-latest" ]]; then
           # Create reproducible tar archive
           echo "Creating reproducible tar.xz archive with SOURCE_DATE_EPOCH=${SOURCE_DATE_EPOCH}"
 
@@ -914,7 +969,7 @@ jobs:
 
           echo "Using ${TAR_TYPE} for archive creation"
 
-          if [[ -z "${{ matrix.config.image }}" ]]; then
+          if [[ -z "$MATRIX_IMAGE" ]]; then
             # GitHub-hosted runner: use sudo for tar command
             sudo bash -c "${TAR_CMD} $DESTDIR | xz -c > \"${DESTDIR}${ARCHIVE_EXT}\""
             sudo chown $(id -u):$(id -g) "${DESTDIR}${ARCHIVE_EXT}"
@@ -924,7 +979,8 @@ jobs:
           fi
         else
           # Windows: 7zip (not fully reproducible, will address with strip-nondeterminism later)
-          ${{ matrix.config.archive_command }} "${DESTDIR}${ARCHIVE_EXT}" $DESTDIR
+          read -r -a archive_command_args <<< "$ARCHIVE_COMMAND"
+          "${archive_command_args[@]}" "${DESTDIR}${ARCHIVE_EXT}" "$DESTDIR"
         fi
       shell: bash
 
@@ -943,8 +999,10 @@ jobs:
     - name: Set ownership of tar archive to root:root
       if: ${{ matrix.config.os != 'windows-latest' }}
       shell: bash
+      env:
+        MATRIX_IMAGE: ${{ matrix.config.image }}
       run: |
-        if [[ -z "${{ matrix.config.image }}" ]]; then
+        if [[ -z "$MATRIX_IMAGE" ]]; then
           sudo chown root:root build/"${DESTDIR}${ARCHIVE_EXT}"
         else
           chown root:root build/"${DESTDIR}${ARCHIVE_EXT}"
@@ -955,6 +1013,9 @@ jobs:
       if: ${{ matrix.config.publish_release }}
       shell: bash
       id: hash
+      env:
+        ARCHIVE_FILE: ${{ format('./build/{0}{1}', steps.release_vars.outputs.destdir, matrix.config.release_extension) }}
+        HASH_OUTPUT_KEY: hash-${{ matrix.config.release_name }}
       run: |
           # sha256sum generates sha256 hash for all artifacts.
           # base64 -w0 encodes to base64 and outputs on a single line.
@@ -962,31 +1023,42 @@ jobs:
           # NOTE: Using suggested method to generate sha across OS's from slsa documentation
           # https://github.com/slsa-framework/slsa-github-generator/blob/main/internal/builders/generic/README.md#provenance-for-artifacts-built-across-multiple-operating-systems
           set -euo pipefail
-          (sha256sum -t ${{ format('./build/{0}{1}', env.DESTDIR, matrix.config.release_extension) }} || shasum -a 256 ${{ format('./build/{0}{1}', env.DESTDIR, matrix.config.release_extension) }}) > checksum
-          echo "hash-${{ matrix.config.release_name }}=$(base64 -w0 checksum || base64 checksum)" >> "${GITHUB_OUTPUT}"
+          (sha256sum -t "$ARCHIVE_FILE" || shasum -a 256 "$ARCHIVE_FILE") > checksum
+          echo "${HASH_OUTPUT_KEY}=$(base64 -w0 checksum || base64 checksum)" >> "${GITHUB_OUTPUT}"
 
     - name: Uploading artifacts
-      uses: actions/upload-artifact@v7.0.0
+      uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
       with:
         name: ${{ format('{0}', matrix.config.release_name) }}
         path: |
-          ${{ format('./build/{0}{1}', env.DESTDIR, matrix.config.release_extension) }}
+          ${{ format('./build/{0}{1}', steps.release_vars.outputs.destdir, matrix.config.release_extension) }}
           build/*.deb
           build/*.rpm
 
     - name: Publish release
       if: ${{ (startsWith(github.ref, 'refs/tags/v') || startsWith(github.ref, 'refs/tags/test-ci')) && matrix.config.publish_release }}
-      uses: softprops/action-gh-release@v2.6.1
-      with:
-        files: |
-          ${{ format('./build/{0}{1}', env.DESTDIR, matrix.config.release_extension) }}
-          build/*.deb
-          build/*.rpm
+      shell: bash
+      env:
+        GH_TOKEN: ${{ github.token }}
+        RELEASE_TAG: ${{ github.ref_name }}
+        ARCHIVE_FILE: ${{ format('./build/{0}{1}', steps.release_vars.outputs.destdir, matrix.config.release_extension) }}
+      run: |
+        set -euo pipefail
+
+        if ! gh release view "$RELEASE_TAG" >/dev/null 2>&1; then
+          gh release create "$RELEASE_TAG" --title "$RELEASE_TAG" --notes "" || gh release view "$RELEASE_TAG" >/dev/null 2>&1
+        fi
+
+        shopt -s nullglob
+        release_files=("$ARCHIVE_FILE" build/*.deb build/*.rpm)
+        gh release upload "$RELEASE_TAG" "${release_files[@]}" --clobber
 
   # This step takes all the generated hashes from all build targets and combines them so slsa provenance step can run
   combine_hashes:
+    name: Combine provenance hashes
     runs-on: ubuntu-latest
     needs: [build]
+    permissions: {}
     outputs:
       hashes: ${{ steps.hashes.outputs.hashes }}
     env:
@@ -1006,7 +1078,7 @@ jobs:
       actions: read # To read the workflow path.
       id-token: write # To sign the provenance.
       contents: write # To add assets to a release.
-    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.1.0
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@f7dd8c54c2067bafc12ca7a55595d5ee9b75204a # v2.1.0
     with:
       base64-subjects: "${{ needs.combine_hashes.outputs.hashes }}"
       upload-assets: true # Optional: Upload to a new release

--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: MPL-2.0
 name: MSBuild
 
+permissions: {}
+
 on:
   push:
     branches:
@@ -28,6 +30,7 @@ env:
 
 jobs:
   build:
+    name: MSBuild ${{ matrix.platform }}
     runs-on: windows-latest
     timeout-minutes: 60
     permissions:
@@ -43,22 +46,29 @@ jobs:
       with:
         egress-policy: audit
 
-    - uses: actions/checkout@v6.0.2
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       continue-on-error: true  # rsync code 24: harmless cleanup-phase race during VM setup
       with:
+        persist-credentials: false
         submodules: recursive
 
     - name: Add MSBuild to PATH
-      uses: microsoft/setup-msbuild@v3.0.0
+      uses: microsoft/setup-msbuild@30375c66a4eea26614e0d39710365f22f8b0af57 # v3.0.0
 
     - name: Restore NuGet packages
       shell: pwsh
-      working-directory: ${{env.GITHUB_WORKSPACE}}
-      run: nuget restore ${{env.SOLUTION_FILE_PATH}}
+      working-directory: ${{ github.workspace }}
+      env:
+        SOLUTION_FILE_PATH: ${{ env.SOLUTION_FILE_PATH }}
+      run: nuget restore $env:SOLUTION_FILE_PATH
 
     - name: Build
       shell: pwsh
-      working-directory: ${{env.GITHUB_WORKSPACE}}
+      working-directory: ${{ github.workspace }}
+      env:
+        BUILD_CONFIGURATION: ${{ env.BUILD_CONFIGURATION }}
+        SOLUTION_FILE_PATH: ${{ env.SOLUTION_FILE_PATH }}
+        BUILD_PLATFORM: ${{ matrix.platform }}
       # Add additional options to the MSBuild command line here (like platform or verbosity level).
       # See https://docs.microsoft.com/visualstudio/msbuild/msbuild-command-line-reference
-      run: msbuild /m /p:Configuration=${{env.BUILD_CONFIGURATION}} ${{env.SOLUTION_FILE_PATH}} /p:Platform=${{matrix.platform}}
+      run: msbuild /m /p:Configuration=$env:BUILD_CONFIGURATION $env:SOLUTION_FILE_PATH /p:Platform=$env:BUILD_PLATFORM

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -3,6 +3,9 @@
 # policy, and support documentation.
 
 name: Scorecard supply-chain security
+
+permissions: {}
+
 on:
   # For Branch-Protection check. Only the default branch is supported. See
   # https://github.com/ossf/scorecard/blob/main/docs/checks.md#branch-protection
@@ -14,8 +17,8 @@ on:
   push:
     branches: [ "develop" ]
 
-# Declare default permissions as read only.
-permissions: read-all
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
 
 jobs:
   analysis:
@@ -24,22 +27,20 @@ jobs:
     # `publish_results: true` only works when run from the default branch. conditional can be removed if disabled.
     if: github.event.repository.default_branch == github.ref_name || github.event_name == 'pull_request'
     permissions:
-      # Needed to upload the results to code-scanning dashboard.
-      security-events: write
-      # Needed to publish results and get a badge (see publish_results below).
-      id-token: write
+      security-events: write # Needed to upload the results to code-scanning dashboard.
+      id-token: write # Needed to publish results and get a badge (see publish_results below).
       # Uncomment the permissions below if installing in a private repository.
       # contents: read
       # actions: read
 
     steps:
       - name: "Checkout code"
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
 
       - name: "Run analysis"
-        uses: ossf/scorecard-action@v2.4.3
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
         with:
           results_file: results.sarif
           results_format: sarif
@@ -64,7 +65,7 @@ jobs:
       # Upload the results as artifacts (optional). Commenting out will disable uploads of run results in SARIF
       # format to the repository Actions tab.
       - name: "Upload artifact"
-        uses: actions/upload-artifact@v7.0.0
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: SARIF file
           path: results.sarif
@@ -73,6 +74,6 @@ jobs:
       # Upload the results to GitHub's code scanning dashboard (optional).
       # Commenting out will disable upload of results to your repo's Code Scanning dashboard
       - name: "Upload to code-scanning"
-        uses: github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action/upload-sarif@c10b8064de6f491fea524254123dbe5e09572f13 # v4.35.1
         with:
           sarif_file: results.sarif

--- a/.github/workflows/source-release.yml
+++ b/.github/workflows/source-release.yml
@@ -1,16 +1,21 @@
 # SPDX-License-Identifier: MPL-2.0
 name: Create Complete Source Archive
 
+permissions: {}
+
 on:
   push:
     tags: [ v* ]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
 
 jobs:
   archive:
     name: ${{ matrix.config.name }}
     runs-on: ${{ matrix.config.os }}
     permissions:
-      contents: write
+      contents: write # Create or update the release for tag builds.
     strategy:
       fail-fast: false # so that if one config fails, other won't be cancelled automatically
       matrix:
@@ -36,23 +41,31 @@ jobs:
       with:
         egress-policy: audit
 
-    - uses: actions/checkout@v6.0.2
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       continue-on-error: true  # rsync code 24: harmless cleanup-phase race during VM setup
       with:
+        persist-credentials: false
         submodules: recursive
 
     - name: Escape backslash in branch name
       shell: bash
-      run: echo "BRANCH_NAME=$(echo ${{ github.ref_name }} | tr / -)" >> $GITHUB_ENV
+      env:
+        REF_NAME: ${{ github.ref_name }}
+      run: echo "BRANCH_NAME=$(echo "$REF_NAME" | tr / -)" >> $GITHUB_ENV
 
     - name: Set release name
+      id: archive_vars
       shell: bash
       run: |
         ARCHIVENAME="openSeaChest-${BRANCH_NAME}"
         echo "ARCHIVENAME=${ARCHIVENAME}" >> $GITHUB_ENV
+        echo "archivename=${ARCHIVENAME}" >> $GITHUB_OUTPUT
 
     - name: Create Source Archive
       shell: bash
+      env:
+        ARCHIVE_PREFIX: ${{ steps.archive_vars.outputs.archivename }}
+        ARCHIVE_EXT: ${{ matrix.config.extension }}
       run: |
         # Set reproducible timestamp from git commit
         export SOURCE_DATE_EPOCH=$(git log -1 --pretty=%ct)
@@ -60,21 +73,28 @@ jobs:
         echo "Timestamp: $(date -u -d @${SOURCE_DATE_EPOCH} 2>/dev/null || date -u -r ${SOURCE_DATE_EPOCH} 2>/dev/null)"
 
         pip install git-archive-all
-        git-archive-all --prefix=${{ env.ARCHIVENAME }}/ SourceCode_With_Submodules${{ matrix.config.extension }}
+        archive_file="SourceCode_With_Submodules${ARCHIVE_EXT}"
+        git-archive-all --prefix="${ARCHIVE_PREFIX}/" "$archive_file"
 
     - name: Verify Source Archive Timestamps
       shell: bash
+      env:
+        ARCHIVE_EXT: ${{ matrix.config.extension }}
       run: |
         echo "Verifying source archive (first 10 files):"
-        if [[ "${{ matrix.config.extension }}" == ".tar.xz" ]]; then
-          tar -tvf SourceCode_With_Submodules${{ matrix.config.extension }} | head -n 10 || true
+        archive_file="SourceCode_With_Submodules${ARCHIVE_EXT}"
+        if [[ "$ARCHIVE_EXT" == ".tar.xz" ]]; then
+          tar -tvf "$archive_file" | head -n 10 || true
         else
-          unzip -l SourceCode_With_Submodules${{ matrix.config.extension }} | head -n 15 || true
+          unzip -l "$archive_file" | head -n 15 || true
         fi
 
     - name: Generate Hashes
       shell: bash
       id: hash
+      env:
+        ARCHIVE_FILE: SourceCode_With_Submodules${{ matrix.config.extension }}
+        HASH_OUTPUT_KEY: hash-SourceCode_With_Submodules-${{ matrix.config.name }}
       run: |
           # sha256sum generates sha256 hash for all artifacts.
           # base64 -w0 encodes to base64 and outputs on a single line.
@@ -82,35 +102,39 @@ jobs:
           # NOTE: Using suggested method to generate sha across OS's from slsa documentation
           # https://github.com/slsa-framework/slsa-github-generator/blob/main/internal/builders/generic/README.md#provenance-for-artifacts-built-across-multiple-operating-systems
           set -euo pipefail
-          (sha256sum -t ${{ format('SourceCode_With_Submodules{0}',  matrix.config.extension) }} || shasum -a 256 ${{ format('SourceCode_With_Submodules{0}',  matrix.config.extension) }}) > checksum
-          echo "hash-SourceCode_With_Submodules-${{ matrix.config.name }}=$(base64 -w0 checksum || base64 checksum)" >> "${GITHUB_OUTPUT}"
+          (sha256sum -t "$ARCHIVE_FILE" || shasum -a 256 "$ARCHIVE_FILE") > checksum
+          echo "${HASH_OUTPUT_KEY}=$(base64 -w0 checksum || base64 checksum)" >> "${GITHUB_OUTPUT}"
 
     - name: Upload Source Archive as Artifact
-      uses: actions/upload-artifact@v7.0.0
+      uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
       with:
         name: SourceCode_With_Submodules-${{ matrix.config.name }}
         path: SourceCode_With_Submodules${{ matrix.config.extension }}
 
     - name: Publish Source Archive to Release
       if: ${{ startsWith(github.ref, 'refs/tags/v') }}
-      uses: softprops/action-gh-release@v2.6.1
+      uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2.6.1
       with:
         files: SourceCode_With_Submodules${{ matrix.config.extension }}
 
   # Generate the slsa provenance
   provenance:
+    name: Generate source provenance
     needs: [archive]
     strategy:
-      fail-fast: false #don't cancel other jobs if one is failing
+      fail-fast: false # don't cancel other jobs if one is failing
       matrix:
-        package_name: [ "SourceCode_With_Submodules-Windows",
-                        "SourceCode_With_Submodules-Linux" ]
+        include:
+          - package_name: "SourceCode_With_Submodules-Windows"
+            base64_subjects: ${{ needs.archive.outputs['hash-SourceCode_With_Submodules-Windows'] }}
+          - package_name: "SourceCode_With_Submodules-Linux"
+            base64_subjects: ${{ needs.archive.outputs['hash-SourceCode_With_Submodules-Linux'] }}
     permissions:
       actions: read # To read the workflow path.
       id-token: write # To sign the provenance.
       contents: write # To add assets to a release.
-    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.1.0
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@f7dd8c54c2067bafc12ca7a55595d5ee9b75204a # v2.1.0
     with:
-      base64-subjects: "${{ needs.archive.outputs[format('hash-{0}', matrix.package_name)] }}"
+      base64-subjects: "${{ matrix.base64_subjects }}"
       # Upload provenance to a new release
       upload-assets: true

--- a/.github/workflows/source-release.yml
+++ b/.github/workflows/source-release.yml
@@ -112,10 +112,16 @@ jobs:
         path: SourceCode_With_Submodules${{ matrix.config.extension }}
 
     - name: Publish Source Archive to Release
-      if: ${{ startsWith(github.ref, 'refs/tags/v') }}
-      uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2.6.1
-      with:
-        files: SourceCode_With_Submodules${{ matrix.config.extension }}
+      shell: bash
+      env:
+        ARCHIVE_FILE: SourceCode_With_Submodules${{ matrix.config.extension }}
+        GH_TOKEN: ${{ github.token }}
+        RELEASE_TAG: ${{ github.ref_name }}
+      run: |
+        if ! gh release view "$RELEASE_TAG" >/dev/null 2>&1; then
+          gh release create "$RELEASE_TAG" --title "$RELEASE_TAG" --notes '' || true
+        fi
+        gh release upload "$RELEASE_TAG" "$ARCHIVE_FILE" --clobber
 
   # Generate the slsa provenance
   provenance:

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,38 @@
+name: Zizmor CI/CD linting
+permissions: {}
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  zizmor:
+    name: zizmor latest via PyPI
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write # Needed to upload the analysis results
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Install the latest version of uv
+        uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
+
+      - name: Run zizmor 🌈
+        run: uvx zizmor --pedantic --format sarif . > results.sarif
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload SARIF file
+        uses: github/codeql-action/upload-sarif@c10b8064de6f491fea524254123dbe5e09572f13 # v4.35.1
+        with:
+          sarif_file: results.sarif
+          category: zizmor

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,4 @@
+rules:
+  dependabot-cooldown:
+    ignore:
+      - dependabot.yml:4


### PR DESCRIPTION
This PR adds Zizmor to the CI/CD pipeline. Zizmor is a tool that scans GitHub Actions and then finds security issues with the way they are setup. We have been using it in our cloudfuse project for a few months and found it very useful. This can help prevent compromises to released packages, etc. that have been becoming very common in the past few months.

I also took a stab at trying to apply fixes for the issues it identified. There are likely a few issues here than can only be identified when running the CI/CD pipelines. Hoping we can have a bit of a back and forth to fix any issues with the runs.