### PR TITLE
lib: Pulling in submodule updates for Realtek USB bridge drives

### DIFF
--- a/utils/C/openSeaChest/openSeaChest_Basics.c
+++ b/utils/C/openSeaChest/openSeaChest_Basics.c
@@ -1282,10 +1282,12 @@ int main(int argc, char* argv[])
 
         if (VERBOSITY_QUIET < toolVerbosity)
         {
-            printf("\n%s - %s - %s - %s - %s\n", deviceList[deviceIter].os_info.name,
-                   deviceList[deviceIter].drive_info.product_identification,
-                   deviceList[deviceIter].drive_info.serialNumber, deviceList[deviceIter].drive_info.product_revision,
-                   print_drive_type(&deviceList[deviceIter]));
+            const char* modelString  = M_NULLPTR;
+            const char* serialString = M_NULLPTR;
+            const char* fwString     = M_NULLPTR;
+            get_Device_Strings_For_Display(&deviceList[deviceIter], &modelString, &serialString, &fwString);
+            printf("\n%s - %s - %s - %s - %s\n", deviceList[deviceIter].os_info.name, modelString, serialString,
+                   fwString, print_drive_type(&deviceList[deviceIter]));
         }
 
 #if defined(FEATURE_JSONOUTPUT_SUPPORT)

--- a/utils/C/openSeaChest/openSeaChest_Configure.c
+++ b/utils/C/openSeaChest/openSeaChest_Configure.c
@@ -2176,10 +2176,12 @@ int main(int argc, char* argv[])
 
         if (VERBOSITY_QUIET < toolVerbosity)
         {
-            printf("\n%s - %s - %s - %s - %s\n", deviceList[deviceIter].os_info.name,
-                   deviceList[deviceIter].drive_info.product_identification,
-                   deviceList[deviceIter].drive_info.serialNumber, deviceList[deviceIter].drive_info.product_revision,
-                   print_drive_type(&deviceList[deviceIter]));
+            const char* modelString  = M_NULLPTR;
+            const char* serialString = M_NULLPTR;
+            const char* fwString     = M_NULLPTR;
+            get_Device_Strings_For_Display(&deviceList[deviceIter], &modelString, &serialString, &fwString);
+            printf("\n%s - %s - %s - %s - %s\n", deviceList[deviceIter].os_info.name, modelString, serialString,
+                   fwString, print_drive_type(&deviceList[deviceIter]));
         }
 
 #if defined(FEATURE_JSONOUTPUT_SUPPORT)

--- a/utils/C/openSeaChest/openSeaChest_Defect.c
+++ b/utils/C/openSeaChest/openSeaChest_Defect.c
@@ -1202,10 +1202,12 @@ int main(int argc, char* argv[])
 
         if (VERBOSITY_QUIET < toolVerbosity)
         {
-            printf("\n%s - %s - %s - %s - %s\n", deviceList[deviceIter].os_info.name,
-                   deviceList[deviceIter].drive_info.product_identification,
-                   deviceList[deviceIter].drive_info.serialNumber, deviceList[deviceIter].drive_info.product_revision,
-                   print_drive_type(&deviceList[deviceIter]));
+            const char* modelString  = M_NULLPTR;
+            const char* serialString = M_NULLPTR;
+            const char* fwString     = M_NULLPTR;
+            get_Device_Strings_For_Display(&deviceList[deviceIter], &modelString, &serialString, &fwString);
+            printf("\n%s - %s - %s - %s - %s\n", deviceList[deviceIter].os_info.name, modelString, serialString,
+                   fwString, print_drive_type(&deviceList[deviceIter]));
         }
 
 #if defined(FEATURE_JSONOUTPUT_SUPPORT)

--- a/utils/C/openSeaChest/openSeaChest_Erase.c
+++ b/utils/C/openSeaChest/openSeaChest_Erase.c
@@ -1864,10 +1864,12 @@ int main(int argc, char* argv[])
 
         if (VERBOSITY_QUIET < toolVerbosity)
         {
-            printf("\n%s - %s - %s - %s - %s\n", deviceList[deviceIter].os_info.name,
-                   deviceList[deviceIter].drive_info.product_identification,
-                   deviceList[deviceIter].drive_info.serialNumber, deviceList[deviceIter].drive_info.product_revision,
-                   print_drive_type(&deviceList[deviceIter]));
+            const char* modelString  = M_NULLPTR;
+            const char* serialString = M_NULLPTR;
+            const char* fwString     = M_NULLPTR;
+            get_Device_Strings_For_Display(&deviceList[deviceIter], &modelString, &serialString, &fwString);
+            printf("\n%s - %s - %s - %s - %s\n", deviceList[deviceIter].os_info.name, modelString, serialString,
+                   fwString, print_drive_type(&deviceList[deviceIter]));
         }
 
 #if defined(FEATURE_JSONOUTPUT_SUPPORT)

--- a/utils/C/openSeaChest/openSeaChest_Firmware.c
+++ b/utils/C/openSeaChest/openSeaChest_Firmware.c
@@ -1038,10 +1038,12 @@ int main(int argc, char* argv[])
 
         if (VERBOSITY_QUIET < toolVerbosity)
         {
-            printf("\n%s - %s - %s - %s - %s\n", deviceList[deviceIter].os_info.name,
-                   deviceList[deviceIter].drive_info.product_identification,
-                   deviceList[deviceIter].drive_info.serialNumber, deviceList[deviceIter].drive_info.product_revision,
-                   print_drive_type(&deviceList[deviceIter]));
+            const char* modelString  = M_NULLPTR;
+            const char* serialString = M_NULLPTR;
+            const char* fwString     = M_NULLPTR;
+            get_Device_Strings_For_Display(&deviceList[deviceIter], &modelString, &serialString, &fwString);
+            printf("\n%s - %s - %s - %s - %s\n", deviceList[deviceIter].os_info.name, modelString, serialString,
+                   fwString, print_drive_type(&deviceList[deviceIter]));
         }
 
 #if defined(FEATURE_JSONOUTPUT_SUPPORT)

--- a/utils/C/openSeaChest/openSeaChest_Format.c
+++ b/utils/C/openSeaChest/openSeaChest_Format.c
@@ -1338,10 +1338,12 @@ int main(int argc, char* argv[])
 
         if (VERBOSITY_QUIET < toolVerbosity)
         {
-            printf("\n%s - %s - %s - %s - %s\n", deviceList[deviceIter].os_info.name,
-                   deviceList[deviceIter].drive_info.product_identification,
-                   deviceList[deviceIter].drive_info.serialNumber, deviceList[deviceIter].drive_info.product_revision,
-                   print_drive_type(&deviceList[deviceIter]));
+            const char* modelString  = M_NULLPTR;
+            const char* serialString = M_NULLPTR;
+            const char* fwString     = M_NULLPTR;
+            get_Device_Strings_For_Display(&deviceList[deviceIter], &modelString, &serialString, &fwString);
+            printf("\n%s - %s - %s - %s - %s\n", deviceList[deviceIter].os_info.name, modelString, serialString,
+                   fwString, print_drive_type(&deviceList[deviceIter]));
         }
 
 #if defined(FEATURE_JSONOUTPUT_SUPPORT)

--- a/utils/C/openSeaChest/openSeaChest_GenericTests.c
+++ b/utils/C/openSeaChest/openSeaChest_GenericTests.c
@@ -1178,10 +1178,12 @@ int main(int argc, char* argv[])
 
         if (VERBOSITY_QUIET < toolVerbosity)
         {
-            printf("\n%s - %s - %s - %s - %s\n", deviceList[deviceIter].os_info.name,
-                   deviceList[deviceIter].drive_info.product_identification,
-                   deviceList[deviceIter].drive_info.serialNumber, deviceList[deviceIter].drive_info.product_revision,
-                   print_drive_type(&deviceList[deviceIter]));
+            const char* modelString  = M_NULLPTR;
+            const char* serialString = M_NULLPTR;
+            const char* fwString     = M_NULLPTR;
+            get_Device_Strings_For_Display(&deviceList[deviceIter], &modelString, &serialString, &fwString);
+            printf("\n%s - %s - %s - %s - %s\n", deviceList[deviceIter].os_info.name, modelString, serialString,
+                   fwString, print_drive_type(&deviceList[deviceIter]));
         }
 
 #if defined(FEATURE_JSONOUTPUT_SUPPORT)

--- a/utils/C/openSeaChest/openSeaChest_Info.c
+++ b/utils/C/openSeaChest/openSeaChest_Info.c
@@ -1024,10 +1024,15 @@ int main(int argc, char* argv[])
 
         if (VERBOSITY_QUIET < toolVerbosity)
         {
-            printf("\n%s - %s - %s - %s - %s\n", deviceList[deviceIter].os_info.name,
-                   deviceList[deviceIter].drive_info.product_identification,
-                   deviceList[deviceIter].drive_info.serialNumber, deviceList[deviceIter].drive_info.product_revision,
-                   print_drive_type(&deviceList[deviceIter]));
+            // When a drive is behind a USB/SAT bridge, the standard drive info fields hold the bridge's SCSI identity
+            // while the actual drive's identity is stored in the bridge info (child MN/SN/FW). Prefer the child drive
+            // identity when it is available so the header shows the real drive.
+            const char* modelString  = M_NULLPTR;
+            const char* serialString = M_NULLPTR;
+            const char* fwString     = M_NULLPTR;
+            get_Device_Strings_For_Display(&deviceList[deviceIter], &modelString, &serialString, &fwString);
+            printf("\n%s - %s - %s - %s - %s\n", deviceList[deviceIter].os_info.name, modelString, serialString,
+                   fwString, print_drive_type(&deviceList[deviceIter]));
         }
 
 #if defined(FEATURE_JSONOUTPUT_SUPPORT)

--- a/utils/C/openSeaChest/openSeaChest_Logs.c
+++ b/utils/C/openSeaChest/openSeaChest_Logs.c
@@ -1067,10 +1067,12 @@ int main(int argc, char* argv[])
 
         if (VERBOSITY_QUIET < toolVerbosity)
         {
-            printf("\n%s - %s - %s - %s - %s\n", deviceList[deviceIter].os_info.name,
-                   deviceList[deviceIter].drive_info.product_identification,
-                   deviceList[deviceIter].drive_info.serialNumber, deviceList[deviceIter].drive_info.product_revision,
-                   print_drive_type(&deviceList[deviceIter]));
+            const char* modelString  = M_NULLPTR;
+            const char* serialString = M_NULLPTR;
+            const char* fwString     = M_NULLPTR;
+            get_Device_Strings_For_Display(&deviceList[deviceIter], &modelString, &serialString, &fwString);
+            printf("\n%s - %s - %s - %s - %s\n", deviceList[deviceIter].os_info.name, modelString, serialString,
+                   fwString, print_drive_type(&deviceList[deviceIter]));
         }
 
 #if defined(FEATURE_JSONOUTPUT_SUPPORT)

--- a/utils/C/openSeaChest/openSeaChest_NVMe.c
+++ b/utils/C/openSeaChest/openSeaChest_NVMe.c
@@ -1126,10 +1126,12 @@ int main(int argc, char* argv[])
 
         if (VERBOSITY_QUIET < toolVerbosity)
         {
-            printf("\n%s - %s - %s - %s - %s\n", deviceList[deviceIter].os_info.name,
-                   deviceList[deviceIter].drive_info.product_identification,
-                   deviceList[deviceIter].drive_info.serialNumber, deviceList[deviceIter].drive_info.product_revision,
-                   print_drive_type(&deviceList[deviceIter]));
+            const char* modelString  = M_NULLPTR;
+            const char* serialString = M_NULLPTR;
+            const char* fwString     = M_NULLPTR;
+            get_Device_Strings_For_Display(&deviceList[deviceIter], &modelString, &serialString, &fwString);
+            printf("\n%s - %s - %s - %s - %s\n", deviceList[deviceIter].os_info.name, modelString, serialString,
+                   fwString, print_drive_type(&deviceList[deviceIter]));
         }
 
 #if defined(FEATURE_JSONOUTPUT_SUPPORT)

--- a/utils/C/openSeaChest/openSeaChest_PassthroughTest.c
+++ b/utils/C/openSeaChest/openSeaChest_PassthroughTest.c
@@ -1140,10 +1140,12 @@ int main(int argc, char* argv[])
 
         if (VERBOSITY_QUIET < toolVerbosity)
         {
-            printf("\n%s - %s - %s - %s - %s\n", deviceList[deviceIter].os_info.name,
-                   deviceList[deviceIter].drive_info.product_identification,
-                   deviceList[deviceIter].drive_info.serialNumber, deviceList[deviceIter].drive_info.product_revision,
-                   print_drive_type(&deviceList[deviceIter]));
+            const char* modelString  = M_NULLPTR;
+            const char* serialString = M_NULLPTR;
+            const char* fwString     = M_NULLPTR;
+            get_Device_Strings_For_Display(&deviceList[deviceIter], &modelString, &serialString, &fwString);
+            printf("\n%s - %s - %s - %s - %s\n", deviceList[deviceIter].os_info.name, modelString, serialString,
+                   fwString, print_drive_type(&deviceList[deviceIter]));
         }
 
 #if defined(FEATURE_JSONOUTPUT_SUPPORT)

--- a/utils/C/openSeaChest/openSeaChest_PowerControl.c
+++ b/utils/C/openSeaChest/openSeaChest_PowerControl.c
@@ -1637,10 +1637,12 @@ int main(int argc, char* argv[])
 
         if (VERBOSITY_QUIET < toolVerbosity)
         {
-            printf("\n%s - %s - %s - %s - %s\n", deviceList[deviceIter].os_info.name,
-                   deviceList[deviceIter].drive_info.product_identification,
-                   deviceList[deviceIter].drive_info.serialNumber, deviceList[deviceIter].drive_info.product_revision,
-                   print_drive_type(&deviceList[deviceIter]));
+            const char* modelString  = M_NULLPTR;
+            const char* serialString = M_NULLPTR;
+            const char* fwString     = M_NULLPTR;
+            get_Device_Strings_For_Display(&deviceList[deviceIter], &modelString, &serialString, &fwString);
+            printf("\n%s - %s - %s - %s - %s\n", deviceList[deviceIter].os_info.name, modelString, serialString,
+                   fwString, print_drive_type(&deviceList[deviceIter]));
         }
 
 #if defined(FEATURE_JSONOUTPUT_SUPPORT)

--- a/utils/C/openSeaChest/openSeaChest_Raw.c
+++ b/utils/C/openSeaChest/openSeaChest_Raw.c
@@ -1374,10 +1374,12 @@ int main(int argc, char* argv[])
 
         if (VERBOSITY_QUIET < toolVerbosity)
         {
-            printf("\n%s - %s - %s - %s - %s\n", deviceList[deviceIter].os_info.name,
-                   deviceList[deviceIter].drive_info.product_identification,
-                   deviceList[deviceIter].drive_info.serialNumber, deviceList[deviceIter].drive_info.product_revision,
-                   print_drive_type(&deviceList[deviceIter]));
+            const char* modelString  = M_NULLPTR;
+            const char* serialString = M_NULLPTR;
+            const char* fwString     = M_NULLPTR;
+            get_Device_Strings_For_Display(&deviceList[deviceIter], &modelString, &serialString, &fwString);
+            printf("\n%s - %s - %s - %s - %s\n", deviceList[deviceIter].os_info.name, modelString, serialString,
+                   fwString, print_drive_type(&deviceList[deviceIter]));
         }
 
 #if defined(FEATURE_JSONOUTPUT_SUPPORT)

--- a/utils/C/openSeaChest/openSeaChest_Reservations.c
+++ b/utils/C/openSeaChest/openSeaChest_Reservations.c
@@ -947,10 +947,12 @@ int main(int argc, char* argv[])
 
         if (VERBOSITY_QUIET < toolVerbosity)
         {
-            printf("\n%s - %s - %s - %s - %s\n", deviceList[deviceIter].os_info.name,
-                   deviceList[deviceIter].drive_info.product_identification,
-                   deviceList[deviceIter].drive_info.serialNumber, deviceList[deviceIter].drive_info.product_revision,
-                   print_drive_type(&deviceList[deviceIter]));
+            const char* modelString  = M_NULLPTR;
+            const char* serialString = M_NULLPTR;
+            const char* fwString     = M_NULLPTR;
+            get_Device_Strings_For_Display(&deviceList[deviceIter], &modelString, &serialString, &fwString);
+            printf("\n%s - %s - %s - %s - %s\n", deviceList[deviceIter].os_info.name, modelString, serialString,
+                   fwString, print_drive_type(&deviceList[deviceIter]));
         }
 
 #if defined(FEATURE_JSONOUTPUT_SUPPORT)

--- a/utils/C/openSeaChest/openSeaChest_SMART.c
+++ b/utils/C/openSeaChest/openSeaChest_SMART.c
@@ -1216,10 +1216,12 @@ int main(int argc, char* argv[])
 
         if (VERBOSITY_QUIET < toolVerbosity)
         {
-            printf("\n%s - %s - %s - %s - %s\n", deviceList[deviceIter].os_info.name,
-                   deviceList[deviceIter].drive_info.product_identification,
-                   deviceList[deviceIter].drive_info.serialNumber, deviceList[deviceIter].drive_info.product_revision,
-                   print_drive_type(&deviceList[deviceIter]));
+            const char* modelString  = M_NULLPTR;
+            const char* serialString = M_NULLPTR;
+            const char* fwString     = M_NULLPTR;
+            get_Device_Strings_For_Display(&deviceList[deviceIter], &modelString, &serialString, &fwString);
+            printf("\n%s - %s - %s - %s - %s\n", deviceList[deviceIter].os_info.name, modelString, serialString,
+                   fwString, print_drive_type(&deviceList[deviceIter]));
         }
 
 #if defined(FEATURE_JSONOUTPUT_SUPPORT)

--- a/utils/C/openSeaChest/openSeaChest_Sample.c
+++ b/utils/C/openSeaChest/openSeaChest_Sample.c
@@ -849,10 +849,12 @@ int main(int argc, char* argv[])
 
         if (VERBOSITY_QUIET < toolVerbosity)
         {
-            printf("\n%s - %s - %s - %s - %s\n", deviceList[deviceIter].os_info.name,
-                   deviceList[deviceIter].drive_info.product_identification,
-                   deviceList[deviceIter].drive_info.serialNumber, deviceList[deviceIter].drive_info.product_revision,
-                   print_drive_type(&deviceList[deviceIter]));
+            const char* modelString  = M_NULLPTR;
+            const char* serialString = M_NULLPTR;
+            const char* fwString     = M_NULLPTR;
+            get_Device_Strings_For_Display(&deviceList[deviceIter], &modelString, &serialString, &fwString);
+            printf("\n%s - %s - %s - %s - %s\n", deviceList[deviceIter].os_info.name, modelString, serialString,
+                   fwString, print_drive_type(&deviceList[deviceIter]));
         }
 
 #if defined(FEATURE_JSONOUTPUT_SUPPORT)

--- a/utils/C/openSeaChest/openSeaChest_Security.c
+++ b/utils/C/openSeaChest/openSeaChest_Security.c
@@ -1435,10 +1435,12 @@ int main(int argc, char* argv[])
 
         if (VERBOSITY_QUIET < toolVerbosity)
         {
-            printf("\n%s - %s - %s - %s - %s\n", deviceList[deviceIter].os_info.name,
-                   deviceList[deviceIter].drive_info.product_identification,
-                   deviceList[deviceIter].drive_info.serialNumber, deviceList[deviceIter].drive_info.product_revision,
-                   print_drive_type(&deviceList[deviceIter]));
+            const char* modelString  = M_NULLPTR;
+            const char* serialString = M_NULLPTR;
+            const char* fwString     = M_NULLPTR;
+            get_Device_Strings_For_Display(&deviceList[deviceIter], &modelString, &serialString, &fwString);
+            printf("\n%s - %s - %s - %s - %s\n", deviceList[deviceIter].os_info.name, modelString, serialString,
+                   fwString, print_drive_type(&deviceList[deviceIter]));
         }
 
 #if defined(FEATURE_JSONOUTPUT_SUPPORT)

--- a/utils/C/openSeaChest/openSeaChest_ZBD.c
+++ b/utils/C/openSeaChest/openSeaChest_ZBD.c
@@ -937,10 +937,12 @@ int main(int argc, char* argv[])
 
         if (VERBOSITY_QUIET < toolVerbosity)
         {
-            printf("\n%s - %s - %s - %s - %s\n", deviceList[deviceIter].os_info.name,
-                   deviceList[deviceIter].drive_info.product_identification,
-                   deviceList[deviceIter].drive_info.serialNumber, deviceList[deviceIter].drive_info.product_revision,
-                   print_drive_type(&deviceList[deviceIter]));
+            const char* modelString  = M_NULLPTR;
+            const char* serialString = M_NULLPTR;
+            const char* fwString     = M_NULLPTR;
+            get_Device_Strings_For_Display(&deviceList[deviceIter], &modelString, &serialString, &fwString);
+            printf("\n%s - %s - %s - %s - %s\n", deviceList[deviceIter].os_info.name, modelString, serialString,
+                   fwString, print_drive_type(&deviceList[deviceIter]));
         }
 
 #if defined(FEATURE_JSONOUTPUT_SUPPORT)


### PR DESCRIPTION
Update all tools to display the real drive identity for drives behind USB bridges using get_Device_Strings_For_Display().

Resolves Seagate/openSeaChest#109